### PR TITLE
Make `tox` build the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+docs/src/examples
+
 *build*
+*egg-info/

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -1,9 +1,5 @@
 # Sphinx documentation build configuration file
 
-import os
-import re
-import time
-
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
@@ -31,6 +27,6 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build"]
 
 project = "cosmo-software-cookbook"
-copyright = f"BSD 3-Clause License, Copyright (c) 2023, cosmo software cookbook team"
+copyright = "BSD 3-Clause License, Copyright (c) 2023, cosmo software cookbook team"
 
 htmlhelp_basename = "cosmo-software-cookbook"

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,11 @@
+[tox]
+min_version = 4.0
+envlist =
+    docs
+
 [testenv:docs]
 deps =
     -r docs/requirements.txt
-commands = sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
+
+commands =
+    sphinx-build {posargs:-E} -W -b html docs/src docs/build/html


### PR DESCRIPTION
Without requiring `tox -e docs`