### PR TITLE
Remove patchelf of _rascal .so since it has been fixed in librascal

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -59,9 +59,3 @@ print(root_index_rst_content)
 
 with open('index.rst', 'w') as f:
     f.write(root_index_rst_content)
-
-# Temporary needed to update rpath correctly so we can include the prebuilt rascal version
-import os
-import rascal
-rascal_shared_lib_path = '/'.join(rascal.__file__.split("/")[:-1]) + '/lib/_rascal.cpython-310-x86_64-linux-gnu.so'
-os.system(f"patchelf --force-rpath --set-rpath '$ORIGIN/../../../../../lib:$ORIGIN/../../lib:$ORIGIN/../../src:$ORIGIN/../src:$ORIGIN/../../rascal.libs' {rascal_shared_lib_path}")

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,5 @@ allowlist_externals=patchelf
 commands =
     pip install -r docs/requirements.txt
     pip install -r docs/requirements-prebuilt.txt
-    pip install patchelf
-
-    # Temporary needed to update rpath correctly so we can include the prebuilt rascal version
-    patchelf --force-rpath --set-rpath '$ORIGIN/../../../../../lib:$ORIGIN/../../lib:$ORIGIN/../../src:$ORIGIN/../src:$ORIGIN/../../rascal.libs' .tox/docs/lib/python3.10/site-packages/rascal/lib/_rascal.cpython-310-x86_64-linux-gnu.so
 
     sphinx-build {posargs:-E} -W -b html docs/src docs/build/html


### PR DESCRIPTION


<!-- readthedocs-preview software-cookbook start -->
----
:books: Documentation preview :books:: https://software-cookbook--22.org.readthedocs.build/en/22/

<!-- readthedocs-preview software-cookbook end -->