### PR TITLE
Update equistore to metatensor

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
     - cmake
   tools:
     python: "3.10"
-    rust: "1.61"
+    rust: "1.64"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, equistore developers
+Copyright (c) 2023, cosmo software cookbook developers
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,7 +20,7 @@ scipy
 scikit-learn
 skmatter
 chemiscope
-equisolve @ https://github.com/lab-cosmo/equisolve/archive/pre_build.zip
+equisolve @ git+https://github.com/lab-cosmo/equisolve.git@71b3dfd
 
-equistore
+metatensor
 rascaline

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -61,7 +61,7 @@ with open('index.rst', 'w') as f:
 intersphinx_mapping = {
     "ase": ("https://wiki.fysik.dtu.dk/ase/", None),
     "chemiscope": ('https://chemiscope.org/docs/', None),
-    "equistore": ("https://lab-cosmo.github.io/equistore/latest/", None),
+    "metatensor": ("https://lab-cosmo.github.io/metatensor/latest/", None),
     "equisolve": ("https://lab-cosmo.github.io/equisolve/latest/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),


### PR DESCRIPTION
besides the standard equistore to metatensor replacement, the prebuilt equisolve have been updated to most recent commit

<!-- readthedocs-preview software-cookbook start -->
----
:books: Documentation preview :books:: https://software-cookbook--26.org.readthedocs.build/en/26/

<!-- readthedocs-preview software-cookbook end -->