### PR TITLE
Start workflows every now and then

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
     tags: ["*"]
   pull_request:
     # Check all PR
+  schedule:
+    - cron: '0 8 * * 1' # run every Monday at 8am UTC
 
 jobs:
   build-and-publish:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ name: Lint
 on:
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 8 * * 1' # run every Monday at 8am UTC
 
 jobs:
   lint:


### PR DESCRIPTION
The workflow runs every Monday at 8am UTC.
I hope it is correct I followed [this guide](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#scheduled-events-schedule) 
So far, only `lint`and `docs` run regularly. Do we want also the artefacts upload to do the same?