### PR TITLE
Fix path of get_examples in the build-and-publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
 
       - id: collectExamples
         run: |
-          echo examplesjson=$(./developer/get_examples.py) >> $GITHUB_OUTPUT
+          echo examplesjson=$(./src/get_examples.py) >> $GITHUB_OUTPUT
 
   generate-example:
     needs: setup


### PR DESCRIPTION
"cleanups" broke things... oops!