### PR TITLE
Update reference branch following i-pi merge

### DIFF
--- a/examples/heat-capacity/environment.yml
+++ b/examples/heat-capacity/environment.yml
@@ -7,6 +7,6 @@ dependencies:
   - pip:
     - ase==3.22.1
     - chemiscope>=0.7
-    - git+https://github.com/i-pi/i-pi.git@heat-capacity-clean  
+    - git+https://github.com/i-pi/i-pi.git@main
     - matplotlib
     - skmatter


### PR DESCRIPTION
As the title says, this is just because the branch this referred to has now been removed. 