### PR TITLE
Clean up the main page, and remove useless SG logs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -132,8 +132,6 @@ Support
 If you still have problems adding your example to the repository, please feel
 free to contact one of the developers, e.g.
 
-`@agoscinski (Alexander Goscinski) <alexander.goscinski@epfl.ch>`_
-
 `@davidetisi (Davide Tisi) <davide.tisi@epfl.ch>`_
 
 Code of Conduct

--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -16,6 +16,9 @@ can also be downloaded as a stand-alone ``.py`` script, or a
 To simplify setting up an environment that contains all the dependencies
 needed for each recipe, you can also download an ``environment.yml`` file 
 that you can use with conda to create a custom environment to run the example.
+If you have never used conda before, you may want to read this
+`beginners guide 
+<https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html>`_.
 
 .. code-block:: bash
 
@@ -25,10 +28,12 @@ that you can use with conda to create a custom environment to run the example.
    # when you want to use the environment
    conda env activate --name <environment-name>
 
-Additional data needed for each example is usually either downloaded
-dynamically, or can be found in a ``data`` folder for each example,
-or downloaded as a ``data.zip`` file at the end of each recipe in
-the website.
+You can then execute the script from the command line, or open the
+notebook in Jupyter lab.  Additional data needed for each example is usually 
+either downloaded dynamically, or can be found in a ``data`` folder for each 
+example, or downloaded as a ``data.zip`` file at the end of each recipe in
+the website. In the latter case, don't forget to unzip the file in the 
+same folder as the ``.py`` or ``.ipynb`` files for the example. 
 
 .. marker-install-end
 

--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -1,0 +1,37 @@
+Installing a recipe
+===================
+
+The main repository contains the source files of all recipes, but you 
+should only fetch the entire repository if you plan on contributing 
+one (see also  <CONTRIBUTING.rst>`_). If you are interested in learning
+the techniques discussed in a specific recipe, this is not recommended,
+as you will also have to understand the build mechanism for the 
+website.
+
+.. marker-install-start
+
+Each recipe can be viewed online as an interactive HTML page, but 
+can also be downloaded as a stand-alone ``.py`` script, or a  
+``.ipynb`` Jupyter notebook. 
+To simplify setting up an environment that contains all the dependencies
+needed for each recipe, you can also download an ``environment.yml`` file 
+that you can use with conda to create a custom environment to run the example.
+
+.. code-block:: bash
+
+   # Pick a name for the environment and replace <environment-name> with it
+   conda env create --name <environment-name> --file environment.yml
+
+   # when you want to use the environment
+   conda env activate --name <environment-name>
+
+Additional data needed for each example is usually either downloaded
+dynamically, or can be found in a ``data`` folder for each example,
+or downloaded as a ``data.zip`` file at the end of each recipe in
+the website.
+
+.. marker-install-end
+
+
+
+

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
 Atomistic Cookbook
 ==================
 
-The source code for the Atomistic Cookbook is maintained
-as a GitHub pages site.
-The home page is accessible at https://atomistic-cookbook.org
+This repository contains the source code for the Atomistic Cookbook,
+that is automatically compiled and deployed as a GitHub pages site,
+accessible at https://atomistic-cookbook.org
 
 .. marker-intro-start
 
-This cookbook contains recipes for atomic-scale modelling for materials and
+The cookbook contains recipes for atomic-scale modelling for materials and
 molecules, with a particular focus on machine learning and statistical
 sampling methods.
 Most of the examples rely heavily on software developed by the laboratory of
@@ -18,9 +18,16 @@ Rather than focusing on the usage of a specific package, this cookbook provides
 concrete examples of the solution of modeling problems, often using a combination
 of several tools.
 
+You can view the recipes online, compiled as webpages containing explanations,
+code snippets, plots and interactive viewers based on 
+`chemiscope <https://chemiscope.org>`_. However, it is also possible (and 
+hopefully simple) to download scripts, and environments, to run the recipe
+on your computer, and that you can use as a starting point to adapt them  
+to your own use case.
+
 .. marker-intro-end
 
-Contributors
+Contributing
 ------------
 
 If you want contribute an example, recipe or tutorial that combines multiple software

--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,11 @@ concrete examples of the solution of modeling problems, often using a combinatio
 of several tools.
 
 You can view the recipes online, compiled as webpages containing explanations,
-code snippets, plots and interactive viewers based on 
-`chemiscope <https://chemiscope.org>`_. However, it is also possible (and 
-hopefully simple) to download scripts, and `conda environments 
-<https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html>`_, 
-to run the recipe on your computer, and that you can use as a starting point to 
+code snippets, plots and interactive viewers based on
+`chemiscope <https://chemiscope.org>`_. However, it is also possible (and
+hopefully simple) to download scripts, and `conda environments
+<https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html>`_,
+to run the recipe on your computer, and that you can use as a starting point to
 adapt them to your own use case.
 
 .. marker-intro-end

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,10 @@ of several tools.
 You can view the recipes online, compiled as webpages containing explanations,
 code snippets, plots and interactive viewers based on 
 `chemiscope <https://chemiscope.org>`_. However, it is also possible (and 
-hopefully simple) to download scripts, and environments, to run the recipe
-on your computer, and that you can use as a starting point to adapt them  
-to your own use case.
+hopefully simple) to download scripts, and `conda environments 
+<https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html>`_, 
+to run the recipe on your computer, and that you can use as a starting point to 
+adapt them to your own use case.
 
 .. marker-intro-end
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -45,6 +45,9 @@ html_js_files = [
 
 htmlhelp_basename = "The Atomistic Cookbook"
 html_theme = "furo"
+html_theme_options = {
+    "top_of_page_buttons": [],
+}
 html_static_path = ["_static"]
 html_favicon = "_static/cookbook-icon.png"
 html_logo = "_static/cookbook-icon.svg"

--- a/docs/src/downloading.rst
+++ b/docs/src/downloading.rst
@@ -1,0 +1,6 @@
+Downloading and running the recipes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../../INSTALLING.rst
+   :start-after: marker-install-start
+   :end-before: marker-install-end

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -5,29 +5,6 @@ The Atomistic Cookbook
    :start-after: marker-intro-start
    :end-before: marker-intro-end
 
-Downloading and running the recipes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Each recipe can be viewed online as an interactive HTML page, but 
-can also be downloaded as a stand-alone ``.py`` script of 
-``.ipynb`` Jupyter notebook. 
-To simplify setting up an environment that contains all the dependencies
-needed for each recipe, you can also download an ``environment.yml`` file 
-that you can use with conda to create a custom environment to run the example.
-
-.. code-block:: bash
-
-   # Pick a name for the environment and replace <environment-name> with it
-   conda env create --name <environment-name> --file environment.yml
-
-   # when you want to use the environment
-   conda env activate --name <environment-name>
-
-Additional data needed for each example is usually either downloaded
-dynamically, or can be found in a ``data`` folder for each example,
-or downloaded as a ``data.zip`` file at the end of each recipe in
-the website.
-
 Table of contents
 ~~~~~~~~~~~~~~~~~
 
@@ -37,6 +14,7 @@ Table of contents
    topics/index
    software/index
    all-examples
+   downloading
    contributing
    
 Recipe of the day

--- a/src/generate-gallery.py
+++ b/src/generate-gallery.py
@@ -40,7 +40,7 @@ class PseudoSphinxApp:
             "filename_pattern": ".*",
             "examples_dirs": os.path.join(ROOT, example),
             "gallery_dirs": gallery_dir,
-            "min_reported_time": 60,
+            "write_computation_times": False,
             "copyfile_regex": r".*\.(sh|xyz|cp2k|yml|png|zip)",
             "matplotlib_animations": True,
             "within_subsection_order": "FileNameSortKey",


### PR DESCRIPTION
This is a bit of overall cleanup, removing unnecessary log files that were uploaded and linked, as well as a link to the .rst source of each file, that was really unnecessary. Also improved the installation instructions, clarifying that the installation of single recipes is different from the installation of the whole cookbook repo. 