### PR TITLE
Temporary fix to install rascaline without the project name change

### DIFF
--- a/examples/periodic-hamiltonian/environment.yml
+++ b/examples/periodic-hamiltonian/environment.yml
@@ -17,7 +17,7 @@ dependencies:
       - metatensor-operations
       - metatensor-torch
       - --extra-index-url https://download.pytorch.org/whl/cpu 
-      - rascaline-torch @ git+https://github.com/luthaf/rascaline#subdirectory=python/rascaline-torch
+      - rascaline-torch @ git+https://github.com/luthaf/rascaline@fe18eccd72402baa48f6a74aa0f3d2e1b277dd52#subdirectory=python/rascaline-torch
       - lightning
       - xitorch
       - keras_core

--- a/examples/periodic-hamiltonian/environment.yml
+++ b/examples/periodic-hamiltonian/environment.yml
@@ -17,7 +17,7 @@ dependencies:
       - metatensor-operations
       - metatensor-torch
       - --extra-index-url https://download.pytorch.org/whl/cpu 
-      - rascaline-torch @ git+https://github.com/luthaf/rascaline@fe18eccd72402baa48f6a74aa0f3d2e1b277dd52#subdirectory=python/rascaline-torch
+      - rascaline-torch @ git+https://github.com/luthaf/rascaline@3450bc4d609aee87ab73648b059536baa97d15ac#subdirectory=python/rascaline-torch
       - lightning
       - xitorch
       - keras_core


### PR DESCRIPTION
Install specific rascaline commit (before the project renaming)