### PR TITLE
Center cookbook text below logo

### DIFF
--- a/docs/src/_static/cookbook.css
+++ b/docs/src/_static/cookbook.css
@@ -1,0 +1,4 @@
+/* center logo text */
+.sidebar-brand-text {
+    text-align: center;
+}

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -160,3 +160,4 @@ def post_build_tweaks(app, exception):
 
 def setup(app):
     app.connect("build-finished", post_build_tweaks)
+    app.add_css_file("cookbook.css")


### PR DESCRIPTION
I think looks better if the text below the logo is centered. I changed this by using a simple addition to the css

# Before

![Screenshot 2025-01-22 at 13 40 42](https://github.com/user-attachments/assets/8bb8a1f1-ef71-47b4-a4da-af38006dae1d)

# After

![Screenshot 2025-01-22 at 13 40 26](https://github.com/user-attachments/assets/a5cb7052-b72c-48d7-b13b-6c2f90e97aff)
