### PR TITLE
Add full example into downloadable zip file.

### DIFF
--- a/INSTALLING.rst
+++ b/INSTALLING.rst
@@ -2,19 +2,20 @@ Installing a recipe
 ===================
 
 The main repository contains the source files of all recipes, but you 
-should only fetch the entire repository if you plan on `contributing one
-<CONTRIBUTING.rst>`_. If you are interested in learning
-the techniques discussed in a specific recipe, this is not recommended,
-as you will also have to understand the build mechanism for the 
-website.
+should only fetch the entire repository if you plan on 
+`contributing a recipe <CONTRIBUTING.rst>`_. 
+If you are interested in learning the techniques discussed in a specific 
+recipe, this is not recommended, as you will also have to understand the 
+build mechanism for the website.
 
 .. marker-install-start
 
 Each recipe can be viewed online as an interactive HTML page, but 
 can also be downloaded as a stand-alone ``.py`` script, or a  
-``.ipynb`` Jupyter notebook. 
-To simplify setting up an environment that contains all the dependencies
-needed for each recipe, you can also download an ``environment.yml`` file 
+``.ipynb`` Jupyter notebook. To simplify setting up an environment that 
+contains all the dependencies needed for each recipe, each recipe can
+be downloaded as an archive that contains the script and notebook
+versions, together with any necessary data file and an ``environment.yml`` file 
 that you can use with conda to create a custom environment to run the example.
 If you have never used conda before, you may want to read this
 `beginners guide 
@@ -22,21 +23,38 @@ If you have never used conda before, you may want to read this
 
 .. code-block:: bash
 
-   # Pick a name for the environment and replace <environment-name> with it
-   conda env create --name <environment-name> --file environment.yml
+   # Deflate the downloaded archive of the recipe 
+   unzip recipe_name.zip
+   
+   # Pick a path where to create the environment and replace 
+   # <environment-folder> with it - this creates a local folder 
+   # to avoid cluttering the global conda folder
+   conda env create --prefix <environment-folder/> --file environment.yml
 
-   # when you want to use the environment
-   conda env activate --name <environment-name>
+   # When you want to use the environment
+   conda env activate --name <environment-folder/>
+   
+   # You should be able to run the recipe within the environment 
+   python recipe-file.py
 
-You can then execute the script from the command line, or open the
-notebook in Jupyter lab.  Additional data needed for each example is usually 
-either downloaded dynamically, or can be found in a ``data`` folder for each 
-example, or downloaded as a ``data.zip`` file at the end of each recipe in
-the website. In the latter case, don't forget to unzip the file in the 
-same folder as the ``.py`` or ``.ipynb`` files for the example. 
+If you want to run the notebook, you also have to create a kernel that uses
+the environment. Assuming you have a functioning Jupyter installation globally,
+you should run
 
+.. code-block:: bash
+
+   # Activate the environment 
+   conda env activate --name <environment-folder/>
+   pip install ipykernel # in case is not part of the environment
+   
+   # Create the kernel definition
+   python -m ipykernel install --user --name recipe_env --display-name "Python (recipe_env)"
+   
+   # You can launch Jupyter from outside the conda environment,
+   # unless you also need conda-installed executables. When you open
+   # the notebook, make sure you selected "Python (recipe_env)" as the 
+   # kernel to run it
+   jupyter lab recipe-file.ipynb
+   
 .. marker-install-end
-
-
-
 

--- a/docs/src/_static/cookbook.css
+++ b/docs/src/_static/cookbook.css
@@ -2,3 +2,8 @@
 .sidebar-brand-text {
     text-align: center;
 }
+
+/* Hide sphinx gallery download buttons */
+.sphx-glr-download-jupyter, .sphx-glr-download-python{
+    display: none;
+}

--- a/noxfile.py
+++ b/noxfile.py
@@ -290,12 +290,6 @@ for name in EXAMPLES:
         # Gather list of files before running the example
         example_files = list(example_dir.glob("*"))
 
-        # Creates data.zip if there's a data folder
-        if os.path.exists(f"examples/{name}/data"):
-            shutil.make_archive(
-                f"examples/{name}/data", "zip", f"examples/{name}/", "data/"
-            )
-
         session.run("python", "src/generate-gallery.py", example_dir)
 
         # Path of the generated gallery example.
@@ -389,10 +383,9 @@ that are not part of any of the other sections.
 """
         )
         # sort by title
-        for file, metadata in sorted(
+        for _, metadata in sorted(
             all_examples_rst.items(), key=(lambda kw: kw[1]["title"])
         ):
-            root = os.path.dirname(file)
 
             # generates a thumbnail link
             output.write(
@@ -410,39 +403,6 @@ that are not part of any of the other sections.
 
                 """
             )
-
-            # inject custom links into the gallery file
-            with open(file) as fd:
-                content = fd.read()
-
-            if "Download Conda environment file" in content:
-                # do not add the download link twice
-                pass
-            else:
-                lines = content.split("\n")
-                with open(file, "w") as fd:
-                    for line in lines:
-                        if "sphx-glr-download-jupyter" in line:
-                            # add the new download link before
-                            fd.write(
-                                """
-    .. container:: sphx-glr-download
-
-      :download:`Download Conda environment file: environment.yml <environment.yml>`
-"""
-                            )
-
-                            if os.path.exists(os.path.join(root, "data.zip")):
-                                fd.write(
-                                    """
-    .. container:: sphx-glr-download
-
-      :download:`Download data files: data.zip <data.zip>`
-"""
-                                )
-
-                        fd.write(line)
-                        fd.write("\n")
 
         output.write(
             """

--- a/src/generate-gallery.py
+++ b/src/generate-gallery.py
@@ -4,6 +4,7 @@ import sys
 
 import chemiscope  # noqa: F401
 import sphinx_gallery.gen_gallery
+import sphinx_gallery.gen_rst
 from chemiscope.sphinx import ChemiscopeScraper
 
 
@@ -69,6 +70,19 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(f"usage: {sys.argv[0]} <example/dir>")
         sys.exit(1)
+
+    # To change the download text, we change the ZIP_DOWNLOAD variable in
+    # sphinx_gallery.gen_rst. This is a bit of a hack, but arguably not
+    # worse than postmodifying RST. We perform some checks here to make
+    # sure that the hack is still valid and it does not fail silently.
+    assert hasattr(sphinx_gallery.gen_rst, "ZIP_DOWNLOAD")
+    assert isinstance(sphinx_gallery.gen_rst.ZIP_DOWNLOAD, str)
+
+    sphinx_gallery.gen_rst.ZIP_DOWNLOAD = """
+    .. container:: sphx-glr-download sphx-glr-download-zip
+
+        :download:`Download recipe: {0} <{0}>`
+    """
 
     app = PseudoSphinxApp(example=sys.argv[1])
     sphinx_gallery.gen_gallery.fill_gallery_conf_defaults(app, app.config)


### PR DESCRIPTION
Addresses #118 by including all files of a given example in the downloadable zip file.

The approach that I took was to simply overwrite the zip file generated by `sphinx_gallery` with a zip file containing all the files. Then no extra download buttons are needed because `sphinx_gallery` already provides the download button for the zip file.

Some thoughts:

1. With the current implementation, the zip file will contain all the files that are present in the example directory. This might include outputs if this is not the first time that the build/tutorial is run. I think this is fine since in the CI the example directory will always be clean. Anyway, a `clean` command would also be nice to bring the directory to the original state, I don't know if that exists already.
2. I would say there is not really a need for the rest of download buttons since each individual download is not very useful, and having 5 stacked buttons looks ugly :)