### PR TITLE
Only download latest build in PRs, avoid in main CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,7 @@ jobs:
 
       - name: Download latest main branch built examples
         uses: actions/download-artifact@v4
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           path: docs/src/examples
           pattern: example-*


### PR DESCRIPTION
I forgot to add a check to download the latest build only on PRs.

On CI for the main branch we already run all examples so no need for that. The last run failed because of API limits so this PR should remove that problem.