### PR TITLE
Remove warmup epochs from training options

### DIFF
--- a/examples/pet-finetuning/c_ft_options.yaml
+++ b/examples/pet-finetuning/c_ft_options.yaml
@@ -4,7 +4,6 @@ architecture:
   name: pet
   training:
     num_epochs: 20
-    num_epochs_warmup: 1
     learning_rate: 1e-4
     batch_size: 10
 

--- a/examples/pet-finetuning/from_scratch_options.yaml
+++ b/examples/pet-finetuning/from_scratch_options.yaml
@@ -6,7 +6,6 @@ architecture:
   training:
     batch_size: 10
     num_epochs: 50
-    num_epochs_warmup: 10
     learning_rate: 1e-4
     
 

--- a/examples/pet-finetuning/full_ft_options.yaml
+++ b/examples/pet-finetuning/full_ft_options.yaml
@@ -5,7 +5,6 @@ architecture:
   training:
     batch_size: 10
     num_epochs: 50  # very short period for demostration
-    num_epochs_warmup: 1
     learning_rate: 1e-5  # small learning rate to stabilize training
     finetune:
       method: "full"  # use fine-tuning strategy

--- a/examples/pet-finetuning/long_c_ft_options.yaml
+++ b/examples/pet-finetuning/long_c_ft_options.yaml
@@ -4,7 +4,6 @@ architecture:
   name: pet
   training:
     num_epochs: 3000
-    num_epochs_warmup: 10
     learning_rate: 1e-5
     batch_size: 10
 

--- a/examples/pet-finetuning/long_c_options.yaml
+++ b/examples/pet-finetuning/long_c_options.yaml
@@ -6,7 +6,6 @@ architecture:
   training:
     batch_size: 32
     num_epochs: 1000
-    num_epochs_warmup: 10
     learning_rate: 1e-4
     
 

--- a/examples/pet-finetuning/long_nc_options.yaml
+++ b/examples/pet-finetuning/long_nc_options.yaml
@@ -5,7 +5,6 @@ architecture:
   training:
     batch_size: 8
     num_epochs: 700
-    num_epochs_warmup: 100
     learning_rate: 3e-4
 
 training_set:

--- a/examples/pet-finetuning/nc_train_options.yaml
+++ b/examples/pet-finetuning/nc_train_options.yaml
@@ -5,7 +5,6 @@ architecture:
   training:
     batch_size: 10 
     num_epochs: 20
-    num_epochs_warmup: 1
     learning_rate: 1e-4
 
 training_set:


### PR DESCRIPTION
Fixes the `pet-finetuning` example