### PR TITLE
Fix Github API authentication

### DIFF
--- a/src/latest_docs_run.py
+++ b/src/latest_docs_run.py
@@ -25,14 +25,18 @@ def get_latest_successful_docs_run(api_token: Optional[str] = None) -> int:
 
     doc_runs_endpoint = GITHUB_ACTIONS_API + "/workflows/docs.yml/runs"
 
+    headers = {}
+    if api_token is not None:
+        headers["Authorization"] = f"Bearer {api_token}"
+
     response = requests.get(
         doc_runs_endpoint,
+        headers=headers,
         params={
             "branch": "main",
             "per_page": 1,
             "status": "success",
             "exclude_pull_requests": True,
-            "auth": api_token,
         },
     )
 


### PR DESCRIPTION
In the requests to the Github API sent directly by our code, I thought we where authenticating but we were not.

Now it is really following the instructions in : https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api?utm_source=chatgpt.com&apiVersion=2022-11-28#about-authentication.

If the authentication fails we will get a `401: Bad credentials` error.