### PR TITLE
`PETMADCalculator._model` was renamed to `model`

### DIFF
--- a/examples/pet-mad/pet-mad.py
+++ b/examples/pet-mad/pet-mad.py
@@ -142,7 +142,7 @@ calculator = PETMADCalculator(version="1.0.1", device="cpu")
 # external MD engines. This is done by saving the model to a file,
 # which includes the model architecture and weights.
 
-calculator._model.save("pet-mad-v1.1.0.pt")
+calculator.model.save("pet-mad-v1.1.0.pt")
 
 # %%
 # The model can also be loaded from this torchscript dump, which often


### PR DESCRIPTION
Failing test: https://github.com/lab-cosmo/atomistic-cookbook/actions/runs/20653474546/job/59302044938#step:5:2231
> AttributeError: 'PETMADCalculator' object has no attribute '_model'

Upstream definition of `PETMADCalculator.model`:
https://github.com/lab-cosmo/pet-mad/blob/12e970981cd45b805d7aadc524a2009aa52f4cf3/src/pet_mad/calculator.py#L125