### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/examples/batch-cp2k/reference-trajectory.py
+++ b/examples/batch-cp2k/reference-trajectory.py
@@ -69,7 +69,7 @@ else:
 def write_reftraj(fname: str, frames: Union[ase.Atoms, List[ase.Atoms]]) -> None:
     """Writes a list of ase atoms objects to a reference trajectory.
 
-    A reference trajectory is the CP2K compatible format for the compuation of batches.
+    A reference trajectory is the CP2K compatible format for the computation of batches.
     All frames must have the stoichiometry/composition.
     """
 
@@ -84,7 +84,7 @@ def write_reftraj(fname: str, frames: Union[ase.Atoms, List[ase.Atoms]]) -> None
         ):
             raise ValueError(
                 f"Atom symbols in frame {i},{atoms.get_chemical_formula()} are "
-                f"different compared to inital frame "
+                f"different compared to initial frame "
                 f"{frames[0].get_chemical_formula()}. "
                 "CP2K does not support changing atom types within a reftraj run!"
             )

--- a/examples/dos-align/dos-align.py
+++ b/examples/dos-align/dos-align.py
@@ -325,7 +325,7 @@ def evaluate_spline(spline_coefs, spline_positions, x):
     x = torch.clamp(
         x, min=spline_positions[0], max=spline_positions[-1] - 0.0005
     )  # restrict x to fall within the spline interval
-    # 0.0005 is substracted to combat errors arising from precision
+    # 0.0005 is subtracted to combat errors arising from precision
     indexes = torch.floor(
         (x - spline_positions[0]) / interval
     ).long()  # Obtain the index for the appropriate spline coefficients
@@ -438,7 +438,7 @@ train_index = train_index[:val_mark]
 # %%
 # 2) Define the dataloader and the Model Architecture
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# We will now build a dataloader and dataset to facillitate training the model batchwise
+# We will now build a dataloader and dataset to facilitate training the model batchwise
 
 
 def generate_atomstructure_index(n_atoms_per_structure):

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -298,7 +298,7 @@ plt.show()
 # %%
 # In the 100 NEB steps we took, the structure did unfortunately not converge.
 # The metatomic calculator for PET-MAD v1.0.2 provides `LLPR based energy
-# uncertainities <https://atomistic-cookbook.org/examples/pet-mad-uq/pet-mad-uq.html>`_.
+# uncertainties <https://atomistic-cookbook.org/examples/pet-mad-uq/pet-mad-uq.html>`_.
 # As we obtain a warning that the uncertainty of the path structure sampled is
 # very high, we stop after 100 steps.
 # The ASE algorithm with LBFGS optimizer does not

--- a/examples/hamiltonian-qm7/hamiltonian-qm7.py
+++ b/examples/hamiltonian-qm7/hamiltonian-qm7.py
@@ -54,7 +54,7 @@ and our preprint `arXiv:2504.01187 <https://doi.org/10.48550/arXiv.2504.01187>`_
 
 # %%
 # We first show an example where we predict the reduced effective
-# Hamiltonians for a homogenous dataset of ethane molecule while
+# Hamiltonians for a homogeneous dataset of ethane molecule while
 # targeting the MO energies of the def2-TZVP basis. In a second example
 # we will then target multiple properties for a organic molecule dataset,
 # similar to our results described in our preprint
@@ -71,7 +71,7 @@ and our preprint `arXiv:2504.01187 <https://doi.org/10.48550/arXiv.2504.01187>`_
 # %%
 # We start by creating a virtual environment and installing
 # all necessary packages. The required packages are provided
-# in the environment.yml file that can be dowloaded at the end.
+# in the environment.yml file that can be downloaded at the end.
 # We can then import the necessary packages.
 #
 
@@ -174,7 +174,7 @@ save_parameters(
 # In principle one can generate the training data of reference
 # Hamiltonians from a given set of structures, using any
 # electronic structure code. Here we provide a pre-computed,
-# homogenous dataset that contains 100 different
+# homogeneous dataset that contains 100 different
 # configurations of ethane molecule. For all structures, we
 # performed Kohn-Sham density functional theory (DFT)
 # calculations with `PySCF <https://github.com/pyscf/pyscf>`_,
@@ -228,7 +228,7 @@ with ZipFile("hamiltonian-qm7-data.zip", "r") as zObject:
 # `mlelec  <https://github.com/curiosity54/mlelec/tree/qm7>`_.
 # In this section we initialise the ``MoleculeDataset`` where
 # we specify the molecule name, file paths and the desired targets
-# and auxillary data to be used for training for the minimal
+# and auxiliary data to be used for training for the minimal
 # (STO-3G), as well as a larger basis (lb, def2-TZVP).
 # Once the molecular data is prepared, we wrap it into an
 # ``MLDataset`` instance. This class structures the dataset
@@ -283,7 +283,7 @@ ml_data._split_indices(
 # are dependent on single atom centers and two centers
 # for pairwise interactions.
 # To address this, we extend the equivariant SOAP-based
-# features for the atom-centered desciptors
+# features for the atom-centered descriptors
 # to a descriptor capable of describing multiple atomic centers and
 # their connectivities, giving rise to the equivariant pairwise descriptor
 # which simultaneously characterizes the environments for pairs of atoms
@@ -362,7 +362,7 @@ train_dl, val_dl, test_dl = get_dataloader(
 # This provides us a more reliable set of weights to initialise the
 # fine-tuning rather than starting from any random guess,
 # effectively saving us training time by starting the training process
-# closer to the desired minumum.
+# closer to the desired minimum.
 
 
 model = LinearTargetModel(
@@ -648,7 +648,7 @@ plot_parity_properties(
 # Get Data and Prepare Data Set
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # In our last example even though we show an indirect ML model
-# that was trained on a homogenous dataset of different
+# that was trained on a homogeneous dataset of different
 # configurations of ethane, we can also easily extend the
 # framework to use  a much diverse dataset such as the
 # `QM7 dataset <http://quantum-machine.org/datasets/>`_.
@@ -711,7 +711,7 @@ FOLDER_NAME = "output/qm7"
 # and load the QM7
 # dataset we downloaded above from zenodo
 # for the defined number of frames.
-# First, we load all relavant data (geometric structures,
+# First, we load all relevant data (geometric structures,
 # auxiliary matrices -overlap and orbitals-, and
 # targets -fock, dipole moment, and polarisablity-) into a molecule dataset.
 # We do this for the minimal (STO-3G), as well as a larger basis (lb, def2-TZVP).

--- a/examples/lode-linear/lode-linear.py
+++ b/examples/lode-linear/lode-linear.py
@@ -136,7 +136,7 @@ calculator_lr = LodeSphericalExpansion(**LR_HYPERS)
 # Taking a look at the output we find that the resulting
 # :py:class:`metatensor.TensorMap` are quite similar in their structure. The short range
 # :py:class:`metatensor.TensorMap` contains more blocks due to the higher
-# ``max_angular`` paramater we choosed above.
+# ``max_angular`` parameter we chose above.
 #
 # Generate the rotational invariants (power spectra)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/lpr/lpr.py
+++ b/examples/lpr/lpr.py
@@ -70,7 +70,7 @@ frames_defect = [frames_defect[ii] for ii in ids]
 # 4 coordinating atoms. "Defect" refers to structures that contain
 # atoms with coordination numbers other than 4.
 #
-# We use :code:`get_all_distances` funciton of :code:`ase.Atoms` to detect the
+# We use :code:`get_all_distances` function of :code:`ase.Atoms` to detect the
 # number of coordinated atoms.
 
 cur_cutoff = 2.7

--- a/examples/metatomic-plumed/metatomic-plumed.py
+++ b/examples/metatomic-plumed/metatomic-plumed.py
@@ -217,7 +217,7 @@ class CoordinationHistogram(torch.nn.Module):
 # Rather than looking at the atomic coordination, one can also resort to order
 # parameters that capture the angular order. The **Steinhardt order parameters**,
 # specifically :math:`Q_4` and :math:`Q_6` are rotationally invariant and measure the
-# local orientational symmetry around each atom. The standard caclulation works by
+# local orientational symmetry around each atom. The standard calculation works by
 # summing over bond vectors within a cutoff radius which connect a central atom to the
 # neighbors and does not use a weighing within the cutoff radius.
 #
@@ -344,13 +344,13 @@ class SoapCV(torch.nn.Module):
 cutoff = 5.5
 module = CoordinationHistogram(cutoff, cn_list=[6, 8])
 
-# metatdata about the model itself
+# metadata about the model itself
 metadata = mta.ModelMetadata(
     name="Coordination histogram",
     description="Computes smooth histogram of coordination numbers",
 )
 
-# metatdata about what the model can do
+# metadata about what the model can do
 capabilities = mta.ModelCapabilities(
     length_unit="Angstrom",
     outputs={"features": mta.ModelOutput(per_atom=False)},

--- a/examples/path-integrals/README.rst
+++ b/examples/path-integrals/README.rst
@@ -1,4 +1,4 @@
-Running, analizing and visualizing a path integral MD simulation
+Running, analyzing and visualizing a path integral MD simulation
 ================================================================
 
 This example shows how to run a path integral molecular dynamics 

--- a/examples/path-integrals/path-integrals.py
+++ b/examples/path-integrals/path-integrals.py
@@ -35,7 +35,7 @@ import numpy as np
 #    :align: center
 #    :width: 600px
 #
-#    A representation of ther ring-polymer Hamiltonian for a water molecule.
+#    A representation of the ring-polymer Hamiltonian for a water molecule.
 #
 # In order to describe the quantum mechanical nature of light nuclei
 # (nuclear quantum effects) one of the most widely-applicable methods uses
@@ -187,7 +187,7 @@ plt.show()
 # You can also visualize the (very short) trajectory in a way that highlights the fast
 # spreading out of the beads of the ring polymer. We use ``chemiscope``'s ability to
 # visualize custom shaped to interleave the trajectories of the beads, forming a
-# trajectory that shows the connecttions between the replicas of each atom. Each atom
+# trajectory that shows the connections between the replicas of each atom. Each atom
 # and its connections are color-coded.
 
 nbeads, nframes, natoms = (

--- a/examples/periodic-hamiltonian/periodic-hamiltonian.py
+++ b/examples/periodic-hamiltonian/periodic-hamiltonian.py
@@ -92,7 +92,7 @@ torch.set_default_dtype(torch.float64)
 # Start by importing all the modules from the `batch-cp2k
 # tutorial <https://tinyurl.com/cp2krun>`__ and run the cell to install
 # CP2K. Run also the cells up to the one defining ``write_cp2k_in``.
-# The following code snippet defines a slighly modified version of that function,
+# The following code snippet defines a slightly modified version of that function,
 # allowing for non-orthorombic supercell, and accounting for the reftraj file
 # name change.
 #

--- a/examples/pet-finetuning/full_ft_options.yaml
+++ b/examples/pet-finetuning/full_ft_options.yaml
@@ -4,7 +4,7 @@ architecture:
   name: "pet"
   training:
     batch_size: 10
-    num_epochs: 50  # very short period for demostration
+    num_epochs: 50  # very short period for demonstration
     learning_rate: 1e-5  # small learning rate to stabilize training
     finetune:
       method: "full"  # use fine-tuning strategy

--- a/examples/pet-finetuning/pet-ft.py
+++ b/examples/pet-finetuning/pet-ft.py
@@ -284,7 +284,7 @@ display_training_curves(from_scratch_log)
 # ``metatrain`` package. There are multiple strategies to apply
 # fine-tuning, each described in the `documentation
 # <https://metatensor.github.io/metatrain/latest/advanced-concepts/fine-tuning.html>`_.
-# In this example we demostrate a basic full fine-tuning strategy, which adapts all
+# In this example we demonstrate a basic full fine-tuning strategy, which adapts all
 # model weights to the new dataset starting from the pre-trained PET-MAD checkpoint. The
 # process is configured by setting appropriate settings in the YAML options file.
 #

--- a/examples/pet-mad-nc/pet-mad-nc.py
+++ b/examples/pet-mad-nc/pet-mad-nc.py
@@ -435,7 +435,7 @@ MTS (M=8):           {time_lammps_mts / 16:.4f} s/step
 # by running the `metatomic` model on the GPU, which you can achieve
 # by setting ``device cuda`` for the `metatomic` pair style in the LAMMPS input files.
 # The MD integration will however still be run on the CPU, which can become the
-# bottleneck - especially because atomic positions need to be transfered to the GPU
+# bottleneck - especially because atomic positions need to be transferred to the GPU
 # at each call. LAMMPS can also be run directly on the GPU using the KOKKOS package,
 # see `the installation instructions
 # <https://docs.metatensor.org/metatomic/latest/engines/lammps.html>`_ for

--- a/examples/pet-mad/pet-mad.py
+++ b/examples/pet-mad/pet-mad.py
@@ -162,7 +162,7 @@ mad_forces = []
 mad_structures = []
 for structure in test_structures:
     tmp = deepcopy(structure)
-    tmp.calc = copy(calculator)  # avoids ovewriting results.
+    tmp.calc = copy(calculator)  # avoids overwriting results.
     mad_energy.append(tmp.get_potential_energy())
     mad_forces.append(tmp.get_forces())
     mad_structures.append(tmp)
@@ -200,7 +200,7 @@ for i, sub in enumerate(subsets):
 ax[0].set_xlabel("MAD energy / eV/atom")
 ax[0].set_ylabel("Reference energy / eV/atom")
 ax[1].set_xlabel("MAD forces / eV/Å")
-ax[1].set_ylabel("Refrerence forces / eV/Å")
+ax[1].set_ylabel("Reference forces / eV/Å")
 
 fig.legend(loc="upper center", bbox_to_anchor=(0.55, 1.20), ncol=3)
 
@@ -422,7 +422,7 @@ chemiscope.show(
 #
 # Here we use a ``<motion mode="multi">`` block to combine
 # a MD run with a ``<motion mode="atomswap">`` block that
-# attemts swapping atoms, with a Monte Carlo acceptance.
+# attempts swapping atoms, with a Monte Carlo acceptance.
 
 motion_xml = f"""
 <motion mode="multi">

--- a/examples/pi-mts-rpc/mts-rpc.py
+++ b/examples/pi-mts-rpc/mts-rpc.py
@@ -322,7 +322,7 @@ for line in lines[7:13]:
 # components are active at each level of the MTS hierarchy.
 # These weights indicate that the smooth part (full minus short-range)
 # is active in the outer loop, and the short-range part is active in the inner
-# loop. Note that the implementation is smart enough to re-use the short-range
+# loop. Note that the implementation is smart enough to reuse the short-range
 # potential computed in the inner loop, multiplying it with a weight of -1 to
 # compute :math:`V_\mathrm{lr}=V-V_\mathrm{sr}`.
 

--- a/examples/rotate-equivariants/rotate-equivariants.py
+++ b/examples/rotate-equivariants/rotate-equivariants.py
@@ -213,7 +213,7 @@ print(equivariants)
 n_rotations = 100
 rotations = [get_random_rotation() for _ in range(n_rotations)]
 
-# This list containts the rotation matrices that we will use to rotate both the
+# This list contains the rotation matrices that we will use to rotate both the
 # atomic positions and to generate the Wigner D matrices to rotate also the associated
 # equavariants.
 #
@@ -294,7 +294,7 @@ def WignerD_calculator(rotations, L):
 # rotation matrices that we generated. Importantly, we need to change convention using
 # the utility function ``rotation_matrix_conversion_order``.
 
-# Initiaize the L for the comparison with the rotation matrices
+# Initialize the L for the comparison with the rotation matrices
 L = 1
 # Generate the Wigner D matrices
 wigner_D_matrices = WignerD_calculator(rotations, L)
@@ -316,7 +316,7 @@ wigner_D_matrices = WignerD_calculator(rotations, L)
 # list of TensorMaps, one for each rotation.
 rotated_equivariants = []
 for idx, _ in enumerate(rotations):
-    # We obtaine the new values by applying the Wigner D matrices from the right (and
+    # We obtain the new values by applying the Wigner D matrices from the right (and
     # thus we use their transpose)
     new_values = (
         equivariants.block().values.swapaxes(-1, -2) @ wigner_D_matrices[idx].T

--- a/examples/thermostats/README.rst
+++ b/examples/thermostats/README.rst
@@ -5,5 +5,5 @@ This example provides some practical guidelines to set up and
 run simulations using different types of (primarily stochastic)
 thermostats. It discusses both `i-PI <http://ipi-code.org>`_ and
 `LAMMPS <http://lammps.org>`_ as practical codes, and it 
-analizes and visualize the output using ``matplotlib`` and 
+analyzes and visualize the output using ``matplotlib`` and 
 `chemiscope <https://chemiscope.org>`_.

--- a/examples/thermostats/thermostats.py
+++ b/examples/thermostats/thermostats.py
@@ -808,7 +808,7 @@ plt.show()
 
 # %%
 # Especially in the high-frequency region, the deconvolution
-# algorithm succees in recovering the underlying NVE dynamics,
+# algorithm succeeds in recovering the underlying NVE dynamics,
 # which can be useful whenever one wants to optimize statistical
 # efficiency while still being able to estimate dynamical
 # properties.

--- a/examples/water-model/README.rst
+++ b/examples/water-model/README.rst
@@ -1,5 +1,5 @@
 Empircal water models
 =====================
 
-This example shows implemenetations of three and four point flexible water models and
+This example shows implementations of three and four point flexible water models and
 uses them to run molecular dynamics simulations of water.

--- a/examples/water-model/water-model.py
+++ b/examples/water-model/water-model.py
@@ -550,7 +550,7 @@ def get_molecular_geometry(
 
     # adjust neighbor lists to point at the m sites rather than O atoms. this assumes
     # this won't have atoms cross the cutoff, which is of course only approximately
-    # true, so one should use a slighlty larger-than-usual cutoff nb - this is reshaped
+    # true, so one should use a slightly larger-than-usual cutoff nb - this is reshaped
     # to match the values in a NL tensorblock
     nl = system.get_neighbor_list(nlo)
     i_idx = nl.samples.view(["first_atom"]).values.flatten()
@@ -657,7 +657,7 @@ class WaterModel(torch.nn.Module):
 
         # We use a half neighborlist and allow to have pairs farther than cutoff
         # (`strict=False`) since this is not problematic for PME and may speed up the
-        # computation of the neigbors.
+        # computation of the neighbors.
         self.nlo = NeighborListOptions(cutoff=cutoff, full_list=False, strict=False)
 
         self.register_buffer("cutoff", torch.tensor(cutoff))
@@ -855,7 +855,7 @@ The stress is
 #
 # .. note::
 #
-#   We neeed to specify that the model has infinite interaction range because of the
+#   We need to specify that the model has infinite interaction range because of the
 #   presence of a long-range term that means one cannot assume that forces decay to zero
 #   beyond the cutoff.
 


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=ket,nin,ot,propert,struc,ues`

% `codespell --ignore-words-list=ket,nin,ot,propert,struc,ues --write-changes` 