### PR TITLE
Update skmatter version for the lpr example

### DIFF
--- a/examples/lpr/environment.yml
+++ b/examples/lpr/environment.yml
@@ -7,5 +7,5 @@ dependencies:
     - ase==3.22.1
     - matplotlib
     - featomic
-    - skmatter>=0.3
+    - skmatter>=0.3.3
     - requests


### PR DESCRIPTION
Previous `skmatter` versions now make the lpr example fail because some defaults changed somewhere in another package (for a more detailed explanation ask @SanggyuChong :smile: ).