### PR TITLE
Pinned the LAMMPS version to 2025.09.10.mta1 in the PET-MAD example

### DIFF
--- a/examples/pet-mad/environment.yml
+++ b/examples/pet-mad/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
-  - lammps-metatomic
+  - lammps-metatomic=2025.09.10.mta1
   - pip
   - pip:
     - ase


### PR DESCRIPTION
... Until the bug introduced in `2025.09.10.mta2` is fixed