### PR TITLE
Remove variable specification that actually breaks conda environment

### DIFF
--- a/examples/metatomic-plumed/environment.yml
+++ b/examples/metatomic-plumed/environment.yml
@@ -21,4 +21,3 @@ dependencies:
     - featomic-torch
 variables:
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
-  PLUMED_KERNEL: $CONDA_PREFIX/lib/libplumedKernel.so


### PR DESCRIPTION
Make the metatomic-plumed work in statndalone mode