### PR TITLE
chore(deps): another day another pin

### DIFF
--- a/examples/water-pulsed/environment.yml
+++ b/examples/water-pulsed/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
-  - gromacs
+  - "gromacs<2026"
   - pip
   - pip:
     - maicos


### PR DESCRIPTION
GROMACS 2026 isn't compatible with the 2.10 MDAnalysis yet. Not our dep not our problem. PIN.

Failing log:
https://github.com/lab-cosmo/atomistic-cookbook/actions/runs/21524547337/job/62024627394

Passing log:
https://github.com/lab-cosmo/atomistic-cookbook/actions/runs/21132058962/job/60765301980

Or alternatively analyze the system without using the `tpz` (but that's a different PR, and not from me :D)