### PR TITLE
fix(eon-pet-neb): surface sphinx-gallery errors in CI, bump dep pins

### DIFF
--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -15,5 +15,5 @@ dependencies:
     - matplotlib
     - metatrain>=2026.2.1,<2027
     - requests
-    - rgpycrumbs>=1.3.0,<2
-    - chemparseplot>=1.3.0,<2
+    - rgpycrumbs>=1.4.1,<2
+    - chemparseplot>=1.4.2,<2

--- a/src/generate-gallery.py
+++ b/src/generate-gallery.py
@@ -1,11 +1,28 @@
 import os
 import shutil
 import sys
+import traceback
 
 import chemiscope  # noqa: F401
 import sphinx_gallery.gen_gallery
 import sphinx_gallery.gen_rst
 from chemiscope.sphinx import ChemiscopeScraper
+
+
+# Monkey-patch _LoggingTee.write to echo captured output to sys.__stderr__.
+# sphinx-gallery's _LoggingTee replaces both sys.stdout and sys.stderr during
+# recipe execution, so all print output vanishes from CI. sys.__stderr__ is
+# the original fd preserved by Python at startup, immune to replacement.
+_orig_tee_write = sphinx_gallery.gen_rst._LoggingTee.write
+
+
+def _tee_write_with_ci(self, data):
+    _orig_tee_write(self, data)
+    sys.__stderr__.write(data)
+    sys.__stderr__.flush()
+
+
+sphinx_gallery.gen_rst._LoggingTee.write = _tee_write_with_ci
 
 
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), "../"))
@@ -87,4 +104,9 @@ if __name__ == "__main__":
     app = PseudoSphinxApp(example=sys.argv[1])
     sphinx_gallery.gen_gallery.fill_gallery_conf_defaults(app, app.config)
     sphinx_gallery.gen_gallery.update_gallery_conf_builder_inited(app)
-    sphinx_gallery.gen_gallery.generate_gallery_rst(app)
+
+    try:
+        sphinx_gallery.gen_gallery.generate_gallery_rst(app)
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+        sys.exit(1)


### PR DESCRIPTION
sphinx-gallery captures script stdout/stderr internally during recipe execution. When a recipe fails, the traceback is swallowed and CI shows only "failed with exit code 2" with no useful diagnostics. Uses a hacky workaround to keep CI logs useful.

Also bump rgpycrumbs>=1.4.1 and chemparseplot>=1.4.2 to ditch the mistaken  plt_neb migration to chemparseplot.