### PR TITLE
Add links to maintainer sections in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,10 +26,12 @@ If you want contribute an example, recipe or tutorial that combines multiple sof
 tools together, check out the `contributing guidelines <CONTRIBUTING.rst>`_ first.
 
 This project is `maintained
-<https://github.com/lab-cosmo/.github/blob/main/Maintainers.md>`_ by @pfebrer
-and @HaoZeke, who will reply to issues and pull requests opened on this
-repository as soon as possible. You can mention them directly if you did not
-receive an answer after a couple of days.
+<https://github.com/lab-cosmo/.github/blob/main/Maintainers.md>`_ by `@pfebrer
+<https://github.com/pfebrer>`_ and `@HaoZeke <https://github.com/HaoZeke>`_, who
+will reply to issues and pull requests opened on this repository as soon as
+possible. You can mention them directly if you did not receive an answer after a
+couple of days.
 
-It was previously maintained by @DavideTisi (2023 to 2026), many thanks to them
-for their work making the atomistic cookbook awesome!
+It was previously maintained by `@DavideTisi <https://github.com/DavideTisi>`_
+(2023 to 2026), many thanks to them for their work making the atomistic cookbook
+awesome!


### PR DESCRIPTION
Apparently, github does not turn `@foo` into links in README