### PR TITLE
Clean up the pet-mad-dos recipe

### DIFF
--- a/examples/pet-mad-dos/pet-mad-dos.py
+++ b/examples/pet-mad-dos/pet-mad-dos.py
@@ -31,6 +31,7 @@ import torch
 import urllib.request
 import os
 import subprocess
+import chemiscope
 
 # %%
 # Using PET-MAD-DOS out of the box
@@ -269,6 +270,64 @@ plt.ylabel(r"DFT Gap [eV]", size=16)
 plt.legend(fontsize=16)
 plt.tight_layout()
 plt.show()
+
+# %%
+# Step 5: Interactive visualization
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# It is possible to visualize the structures, together with their DOS,
+# in a `chemiscope <https://chemiscope.org>`__ widget.
+# The map shows a parity plot of the bandgap predictions,
+# while the DOS can be visualized by clicking on the
+# ``structure`` info panel.
+
+chemiscope.show(
+    structures=structs,
+    properties={
+        "index": np.arange(len(structs)),
+        "gap": {
+            "target": "structure",
+            "units": "eV",
+            "values": true_bandgap.numpy(),
+            "description": "Reference band gap",
+        },
+        "predicted gap": {
+            "target": "structure",
+            "units": "eV",
+            "values": true_bandgap.numpy(),
+            "description": "Band gap predicted by PET-MAD-DOS",
+        },
+        "DOS": {
+            "target": "structure",
+            "units": "1/eV",
+            "values": true_DOS,
+            "description": "Reference density of states",
+            "parameters": ["energy"],
+        },
+        "predicted DOS": {
+            "target": "structure",
+            "units": "1/eV",
+            "values": pred_DOS,
+            "description": "Density of states predicted by PET-MAD-DOS",
+            "parameters": ["pred_energy"],
+        },
+    },
+    parameters={
+        "energy": {
+            "name": "Energy grid",
+            "units": "eV",
+            "values": true_energy_grid,
+        },
+        "pred_energy": {
+            "name": "Energy grid",
+            "units": "eV",
+            "values": energies,
+        },
+    },
+    settings=chemiscope.quick_settings(x="predicted gap", y="gap", periodic=True),
+)
+
+
 # %%
 # Finetuning PET-MAD-DOS on specific applications
 # --------------------------------------------------


### PR DESCRIPTION
There are a few things that need to be improved in the PET-MAD-DOS recipe. 
Some also require improvements to upet.dos
SMALL TWEAKS:
- [ ]  Have a utility function in upet that pads a given DOS profile
- [ ]  Decrease learning rate for fine-tuning
- [x]  Chemiscope viewer 
- [ ]  use the same energy grid for plotting true and predicted DOS

LARGER THINGS (requiring possibly upet coding):
- [ ]  All the helper functions should be part of the upet.dos package. Doesn't make sense (and it's not sustainable) to have a bunch of opaque magic functions distributed with the recipe. E.g: 
- [ ] computing the energy grid and/or interpolating on a different grid; 
- [ ] computing the alignment; 
- [ ] computing the structure DOS and mask
- [ ]  The recipe starts using only numpy and then switches to torch in get_dynamic_shift_agnostic_mse, which is a bit surprising, and some users might not be used to torch (especially since the calculator exposes an interface based on ASE/numpy)