### PR TITLE
fix(ml-mm): pin libopenblas to satisfy gmx_mpi dynamic loader

### DIFF
--- a/examples/ml-mm/environment.yml
+++ b/examples/ml-mm/environment.yml
@@ -4,6 +4,9 @@ channels:
 dependencies:
   - chemiscope
   - metatensor::gromacs-metatomic=*=mpi_*
+  # gromacs-metatomic links libgromacs against libopenblas.so.0 but the recipe
+  # does not list it as a runtime dependency; pin it here so gmx_mpi can load.
+  - libopenblas
   - libtorch =*=cpu*
   - pytorch-cpu
   - matplotlib

--- a/examples/ml-mm/environment.yml
+++ b/examples/ml-mm/environment.yml
@@ -7,8 +7,15 @@ dependencies:
   # gromacs-metatomic links libgromacs against libopenblas.so.0 but the recipe
   # does not list it as a runtime dependency; pin it here so gmx_mpi can load.
   - libopenblas
-  - libtorch =*=cpu*
-  - pytorch-cpu
+  # Use the cpu_generic libtorch build (linked against openblas) instead of the
+  # default cpu_mkl one. With cpu_mkl, libtorch's mkl_gemm_batched calls
+  # cblas_sgemm_batch, which the dynamic loader resolves to libopenblas (pulled
+  # in by libgromacs) rather than libmkl. The OpenBLAS implementation crashes
+  # because it is being called with MKL's argument layout (SIGSEGV inside
+  # inner_small_matrix_thread). Forcing cpu_generic makes both libtorch and
+  # libgromacs share the same openblas BLAS, eliminating the symbol clash.
+  - libtorch =*=cpu_generic*
+  - pytorch-cpu =*=cpu_generic*
   - matplotlib
   - mdanalysis
   - python=3.12


### PR DESCRIPTION
`libgromacs_mpi.so` links directly against `libopenblas.so.0` (NEEDED entry visible via objdump on the `gromacs-metatomic 2026.0.mta2` build), but the feedstock does not declare `libopenblas` as a runtime dependency. On hosts that happen to have a system-wide `/lib/x86_64-linux-gnu/libopenblas.so.0` the loader silently falls back to the system copy. GitHub Actions `ubuntu-latest` images seem to no longer ship that, so the example crashes with:

    gmx_mpi: error while loading shared libraries:
    libopenblas.so.0: cannot open shared object file: No such file or directory

Listing libopenblas in environment.yml puts the library in the conda prefix and the gromacs RPATH ($ORIGIN/../lib) resolves it correctly... in principle 😅 

=> follow up needed because `torch` otherwise wants the MKL symbol -_-

This should need a `run_exports` update to `gromacs-metatomic-feedstock/recipe/meta.yaml` if it works too.