### PR TITLE
fix(upet): force nvalchemi-toolkit-ops>=0.3.0 to dodge wp.vec regression

### DIFF
--- a/examples/pet-mad-dos/environment.yml
+++ b/examples/pet-mad-dos/environment.yml
@@ -7,4 +7,8 @@ dependencies:
   - matplotlib
   - pip:
     - ase>=3.28
-    - upet>=0.2.2
+    - upet>=0.2.1
+    # upet 0.2.2 hard-pins nvalchemi-toolkit-ops==0.2.0, which uses the removed
+    # wp.vec API and crashes at import on warp-lang>=1.10. Force >=0.3.0 so pip
+    # falls back to upet 0.2.1 (no nvalchemi pin) with the fixed nvalchemi build.
+    - nvalchemi-toolkit-ops>=0.3.0

--- a/examples/pet-phonons/environment.yml
+++ b/examples/pet-phonons/environment.yml
@@ -6,6 +6,10 @@ dependencies:
   - pip:
     - ase>=3.23
     - upet>=0.2.1
+    # upet 0.2.2 hard-pins nvalchemi-toolkit-ops==0.2.0, which uses the removed
+    # wp.vec API and crashes at import on warp-lang>=1.10. Force >=0.3.0 so pip
+    # falls back to upet 0.2.1 (no nvalchemi pin) with the fixed nvalchemi build.
+    - nvalchemi-toolkit-ops>=0.3.0
     - spglib
     - matplotlib
     - numpy

--- a/examples/pet-relaxation/environment.yml
+++ b/examples/pet-relaxation/environment.yml
@@ -6,6 +6,10 @@ dependencies:
   - pip:
     - ase>=3.23
     - upet>=0.2.1
+    # upet 0.2.2 hard-pins nvalchemi-toolkit-ops==0.2.0, which uses the removed
+    # wp.vec API and crashes at import on warp-lang>=1.10. Force >=0.3.0 so pip
+    # falls back to upet 0.2.1 (no nvalchemi pin) with the fixed nvalchemi build.
+    - nvalchemi-toolkit-ops>=0.3.0
     - spglib
     - chemiscope
     - matplotlib

--- a/examples/thermal-conductivity-bte/environment.yml
+++ b/examples/thermal-conductivity-bte/environment.yml
@@ -6,6 +6,10 @@ dependencies:
   - pip:
     - ase>=3.23
     - upet>=0.2.1
+    # upet 0.2.2 hard-pins nvalchemi-toolkit-ops==0.2.0, which uses the removed
+    # wp.vec API and crashes at import on warp-lang>=1.10. Force >=0.3.0 so pip
+    # falls back to upet 0.2.1 (no nvalchemi pin) with the fixed nvalchemi build.
+    - nvalchemi-toolkit-ops>=0.3.0
     - chemiscope>1.0
     - kaldo
     - spglib


### PR DESCRIPTION
All four upet-based examples (`pet-phonons`, `pet-mad-dos`, `pet-relaxation`, `thermal-conductivity-bte`) currently crash at import time with:

```
File ".../nvalchemiops/math/spherical_harmonics.py", line 614, in <module>
    @wp.func
AttributeError: module 'warp' has no attribute 'vec'. Did you mean: 'vec2'?
```

`upet 0.2.2` hard-pins `nvalchemi-toolkit-ops==0.2.0`, whose `spherical_harmonics` module annotates kernels with the generic `wp.vec(length=N, dtype=...)` constructor. NVIDIA Warp removed that alias in `warp-lang 1.10` (only the typed `wp.vec2` / `wp.vec3` / ... remain), so warp's `@wp.func` decorator's annotation evaluation explodes when the module is imported via `metatomic.torch.ase_calculator`. `nvalchemi-toolkit-ops 0.3.0+` switched these kernels to `vec5d` / `vec9d`, which work on `warp-lang 1.13`.

`upet 0.2.1` leaves `nvalchemi-toolkit-ops` unpinned, so requesting `nvalchemi-toolkit-ops>=0.3.0` is enough to make pip backtrack to `upet 0.2.1` + `nvalchemi-toolkit-ops 0.3.1` + `warp-lang 1.13` (resolved on rg.cosmolab as `upet-0.2.1`, `nvalchemi-toolkit-ops-0.3.1`, `warp-lang-1.13.0`, `scipy-1.16.3`, `torch-2.10.0`).

A follow-up upstream fix would be to release a `upet 0.2.3` that pins `nvalchemi-toolkit-ops>=0.3.0` (or unpins it altogether like 0.2.1 did). This is just the cookbook-side workaround.