### PR TITLE
Fix some small incomatibilities following i-pi 3.2.0 release

### DIFF
--- a/examples/flashmd/environment.yml
+++ b/examples/flashmd/environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - pip:
     - ase>=3.23
     - ipi>=3.2.0
-    - vesin[torch]>=0.3.2,<0.4
-    - flashmd>=0.2.2
+    - vesin[torch]>=0.5.5
+    - flashmd>=0.2.8
     - metatrain  
     - chemiscope>=1.0
     - matplotlib

--- a/examples/flashmd/environment.yml
+++ b/examples/flashmd/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - pip:
     - ase>=3.23
-    - ipi==3.1.5
+    - ipi>=3.2.0
     - vesin[torch]>=0.3.2,<0.4
     - flashmd>=0.2.2
     - metatrain  

--- a/examples/flashmd/flashmd-demo.py
+++ b/examples/flashmd/flashmd-demo.py
@@ -31,8 +31,7 @@ You can read more about the model and its limitations in
 import chemiscope
 from flashmd import get_pretrained
 from flashmd.ipi import get_npt_stepper, get_nvt_stepper
-from ipi.utils.parsing import read_output, read_trajectory
-from ipi.utils.scripting import InteractiveSimulation
+from ipi.scripting import read_output, read_trajectory, InteractiveSimulation
 
 
 # %%

--- a/examples/flashmd/flashmd-demo.py
+++ b/examples/flashmd/flashmd-demo.py
@@ -31,7 +31,7 @@ You can read more about the model and its limitations in
 import chemiscope
 from flashmd import get_pretrained
 from flashmd.ipi import get_npt_stepper, get_nvt_stepper
-from ipi.scripting import read_output, read_trajectory, InteractiveSimulation
+from ipi.scripting import InteractiveSimulation, read_output, read_trajectory
 
 
 # %%

--- a/examples/heat-capacity/environment.yml
+++ b/examples/heat-capacity/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - pip:
     - ase>=3.23
     - chemiscope>=1.0
-    - ipi>=3.1.5
+    - ipi>=3.2.0
     - matplotlib

--- a/examples/mendeleev/mendeleev.py
+++ b/examples/mendeleev/mendeleev.py
@@ -28,8 +28,7 @@ import matplotlib.colors as mcolors
 
 
 # i-PI utilities
-from ipi.utils.parsing import read_output, read_trajectory
-from ipi.utils.scripting import InteractiveSimulation
+from ipi.scripting import InteractiveSimulation, read_output, read_trajectory
 
 # %%
 # First, we download the universal potential model. We will use the extra-small (xs)

--- a/examples/metatomic-plumed/environment.yml
+++ b/examples/metatomic-plumed/environment.yml
@@ -16,7 +16,7 @@ dependencies:
     - ase
     - numpy
     - chemiscope>=1.0
-    - ipi>=3.1.5
+    - ipi>=3.2.0
     - metatomic-torch==0.1.7
     - featomic-torch
 variables:

--- a/examples/metatomic-plumed/metatomic-plumed.py
+++ b/examples/metatomic-plumed/metatomic-plumed.py
@@ -663,10 +663,8 @@ lmp_process.wait()
 # so we only run 2000 steps as a demonstration.
 
 ipi_trajectory = ase.io.read("meta-md.pos_0.extxyz", ":")
-ipi_properties, _ = ipi.utils.parsing.read_output("meta-md.out")
-ipi_cv = ipi.utils.parsing.read_trajectory("meta-md.colvar_0", format="extras")[
-    "cv1, cv2"
-]
+ipi_properties, _ = ipi.scripting.read_output("meta-md.out")
+ipi_cv = ipi.scripting.read_trajectory("meta-md.colvar_0", format="extras")["cv1, cv2"]
 
 # %%
 #

--- a/examples/path-integrals/environment.yml
+++ b/examples/path-integrals/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - pip:
     - ase
     - chemiscope>=1.0
-    - ipi  
+    - ipi>=3.2.0  
     - matplotlib

--- a/examples/pet-mad-nc/environment.yml
+++ b/examples/pet-mad-nc/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - ase>=3.27
     - upet>=0.2.3
-    - ipi>=3.1.8,<4.0
+    - ipi>=3.2.0
     - chemiscope>=1.0
     - metatomic-torch
     - matplotlib>=3.10,<4.0

--- a/examples/pet-mad-nc/pet-mad-nc.py
+++ b/examples/pet-mad-nc/pet-mad-nc.py
@@ -48,8 +48,7 @@ import matplotlib.pyplot as plt
 import upet
 
 # i-PI scripting utilities
-from ipi.utils.parsing import read_output, read_trajectory
-from ipi.utils.scripting import InteractiveSimulation
+from ipi.scripting import InteractiveSimulation, read_output, read_trajectory
 
 # metatomic ASE calculator
 from metatomic.torch.ase_calculator import MetatomicCalculator

--- a/examples/pet-mad-uq/environment.yml
+++ b/examples/pet-mad-uq/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pip:
     - ase>=3.27
     - upet>=0.2.3
-    - ipi>=3.1.8,<4
+    - ipi>=3.2.0
     - metatomic-torch
     - metatrain
     - vesin>=0.4.2

--- a/examples/pet-mad/environment.yml
+++ b/examples/pet-mad/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - ase
     - upet>=0.2.3
-    - ipi>=3.1.8
+    - ipi>=3.2.0
     - chemiscope>=1.0
     - matplotlib
     - vesin>=0.4.2

--- a/examples/pet-mad/pet-mad.py
+++ b/examples/pet-mad/pet-mad.py
@@ -60,12 +60,13 @@ import upet
 from ase.optimize import LBFGS
 from upet.calculator import UPETCalculator
 from ipi.utils.mathtools import get_rotation_quadrature_lebedev
-from ipi.utils.parsing import read_output, read_trajectory
-from ipi.utils.scripting import (
+from ipi.scripting import (
     InteractiveSimulation,
     forcefield_xml,
     motion_nvt_xml,
     simulation_xml,
+    read_output,
+    read_trajectory,
 )
 
 

--- a/examples/pi-metad/environment.yml
+++ b/examples/pi-metad/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pip:
     - ase>=3.23
     - chemiscope>=1.0
-    - ipi>=3.1.5.1
+    - ipi>=3.2.0
     - matplotlib
 variables:
   PYTHONPATH:

--- a/examples/pi-mts-rpc/environment.yml
+++ b/examples/pi-mts-rpc/environment.yml
@@ -9,5 +9,5 @@ dependencies:
     - numpy
     - ase>=3.23
     - chemiscope>=1.0
-    - ipi>=3.1.5.1
+    - ipi>=3.2.0
     - matplotlib

--- a/examples/ring-polymer-instanton/environment.yml
+++ b/examples/ring-polymer-instanton/environment.yml
@@ -9,5 +9,5 @@ dependencies:
     - numpy
     - ase>=3.23
     - chemiscope>=1.0
-    - ipi>=3.1.10
+    - ipi>=3.2.0
     - matplotlib

--- a/examples/thermostats/environment.yml
+++ b/examples/thermostats/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - pip:
     - ase>=3.23
     - chemiscope>=1.0
-    - ipi>=3.1.5
+    - ipi>=3.2.0
     - matplotlib

--- a/examples/water-model/environment.yml
+++ b/examples/water-model/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pip:
     - ase
     - chemiscope>=1.0
-    - ipi>=3.1.5
+    - ipi>=3.2.0
     - metatensor-torch>=0.8,<0.9
     - metatensor-operations
     - matplotlib

--- a/examples/water-model/water-model.py
+++ b/examples/water-model/water-model.py
@@ -34,12 +34,13 @@ import torch
 # Core atomistic libraries
 import torchpme
 from ase.optimize import LBFGS
-from ipi.utils.parsing import read_output, read_trajectory
 from ipi.utils.scripting import (
     InteractiveSimulation,
     forcefield_xml,
     motion_nvt_xml,
     simulation_xml,
+    read_output,
+    read_trajectory,
 )
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import (

--- a/examples/water-model/water-model.py
+++ b/examples/water-model/water-model.py
@@ -34,7 +34,7 @@ import torch
 # Core atomistic libraries
 import torchpme
 from ase.optimize import LBFGS
-from ipi.utils.scripting import (
+from ipi.scripting import (
     InteractiveSimulation,
     forcefield_xml,
     motion_nvt_xml,


### PR DESCRIPTION
As the title says. Moving utilties to ipi.scripting broke one of the examples. Took the opportunity to update everything to 3.2.0 so we avoid deprecation warnings