### PR TITLE
Handle Conda warnings during JSON dependency resolution

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import zipfile
 from pathlib import Path
 
@@ -351,24 +352,39 @@ DEPENCENCIES_UPDATES = {
 
 
 def update_dependencies(environment_yml, session):
-    output = session.run(
-        "conda",
-        "env",
-        "create",
-        f"--file={environment_yml}",
-        "--name=atomistic-cookbook-tmp-env",
-        "--solver=libmamba",
-        "--json",
-        "--quiet",
-        "--dry-run",
-        silent=True,
-    )
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stderr:
+        output = session.run(
+            "conda",
+            "env",
+            "create",
+            f"--file={environment_yml}",
+            "--name=atomistic-cookbook-tmp-env",
+            "--solver=libmamba",
+            "--json",
+            "--quiet",
+            "--dry-run",
+            stderr=stderr,
+            silent=True,
+        )
+
+        stderr.seek(0)
+        stderr_output = stderr.read().strip()
+
+    if stderr_output:
+        session.warn(
+            "Conda emitted warnings while resolving dependencies:\n"
+            f"{stderr_output}"
+        )
 
     try:
         data = json.loads(output)
         dependencies = data["dependencies"]
     except json.JSONDecodeError:
-        session.error(f"Conda did not return valid JSON. Output was: {output}")
+        session.error(
+            "Conda did not return valid JSON while resolving dependencies. "
+            "stdout was:\n"
+            f"{output}"
+        )
 
     new_deps = set()
     for dep in dependencies:

--- a/noxfile.py
+++ b/noxfile.py
@@ -372,8 +372,7 @@ def update_dependencies(environment_yml, session):
 
     if stderr_output:
         session.warn(
-            "Conda emitted warnings while resolving dependencies:\n"
-            f"{stderr_output}"
+            f"Conda emitted warnings while resolving dependencies:\n{stderr_output}"
         )
 
     try:


### PR DESCRIPTION
Addresses #228.

This PR updates `update_dependencies()` so that warning output from the `conda env create --json --dry-run` dependency-resolution step does not interfere with parsing the JSON output.

Conda stderr is now captured separately from stdout. If Conda emits warning text while resolving dependencies, it is reported through the Nox session warning mechanism, while `json.loads()` still receives clean stdout JSON.

Validation:

- Reproduced the original failure locally with a fake Conda executable that emits a warning on stderr and valid JSON on stdout.
- Confirmed that after the fix, the warning is shown separately and `update_dependencies()` succeeds.
- Ran `python -m py_compile noxfile.py`.
- Ran `nox -e water-model -- --no-website`; the session completed successfully.