### PR TITLE
Limit metatrain version in eon-pet-neb

### DIFF
--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -12,7 +12,7 @@ dependencies:
     - torch>=2.9,<2.10 
     - ase>=3.23
     - matplotlib
-    - metatrain>=2026.2.1,<2027
+    - metatrain>=2026.2.1,<2026.3
     - requests
     - metatomic-ase
     - rgpycrumbs>=1.7.0,<2


### PR DESCRIPTION
I think `eon` does not yet support the new metatomic/metatensor, am I right @HaoZeke ?