### PR TITLE
chore(eon-pet-neb): pin latest metatomic and eOn/rgpkgs stack

### DIFF
--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -3,25 +3,24 @@ channels:
   - conda-forge
   - https://repo.prefix.dev/rg-forge
 dependencies:
-  # eonclient links libmetatomic-torch; 0.1.15 accepts models from metatrain 2026.3
-  # (sample_kind / optional per_atom). That package requires libtorch >=2.12.
   - eon>=2.15.0
-  - libmetatomic-torch>=0.1.15,<0.2
-  - libmetatensor-torch>=0.10.0,<0.11
-  - libmetatensor>=0.2.2,<0.3
-  - libtorch>=2.12,<2.13
   - ira
   - python=3.13
   - pip
   - uv
   - pip:
+    # Align torch with conda eon 2.15 (libtorch 2.9.x). metatrain 2026.3 embeds
+    # ModelOutput calls for metatomic-torch 0.1.15; conda eon still links
+    # libmetatomic-torch <0.1.15 until a rebuild (TheochemUI/eOn#361). Use the
+    # newest stack that keeps eonclient and mtt export on the same ABI.
+    - torch>=2.9,<2.10
     - ase>=3.23
     - matplotlib
-    - metatrain>=2026.3,<2027
+    - metatrain>=2026.2.1,<2026.3
     - requests
     - metatomic-ase>=0.1.1
-    - metatomic-torch>=0.1.15,<0.2
-    - metatensor-torch>=0.10.0,<0.11
+    - metatomic-torch>=0.1.11,<0.1.15
+    - metatensor-torch>=0.8.4,<0.10
     - rgpycrumbs>=1.8.0,<2
     - chemparseplot>=1.8.0,<2
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -9,18 +9,15 @@ dependencies:
   - pip
   - uv
   - pip:
-    # Align torch with conda eon 2.15 (libtorch 2.9.x). metatrain 2026.3 embeds
-    # ModelOutput calls for metatomic-torch 0.1.15; conda eon still links
-    # libmetatomic-torch <0.1.15 until a rebuild (TheochemUI/eOn#361). Use the
-    # newest stack that keeps eonclient and mtt export on the same ABI.
     - torch>=2.9,<2.10
     - ase>=3.23
     - matplotlib
+    # Keep mtt export on the same metatomic ABI as conda eon 2.15 until
+    # TheochemUI/eOn#361 is released and the feedstock rebuilds against
+    # libmetatomic-torch 0.1.15 (needs libtorch 2.12 on conda-forge).
     - metatrain>=2026.2.1,<2026.3
     - requests
     - metatomic-ase>=0.1.1
-    - metatomic-torch>=0.1.11,<0.1.15
-    - metatensor-torch>=0.8.4,<0.10
     - rgpycrumbs>=1.8.0,<2
     - chemparseplot>=1.8.0,<2
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -3,18 +3,20 @@ channels:
   - conda-forge
   - https://repo.prefix.dev/rg-forge
 dependencies:
-  - eon>=2.12.0
+  - eon>=2.15.0
   - ira
   - python=3.13
   - pip
   - uv
   - pip:
-    - torch>=2.9,<2.10 
+    - torch>=2.9,<2.11
     - ase>=3.23
     - matplotlib
-    - metatrain>=2026.2.1,<2027
+    - metatrain>=2026.3,<2027
     - requests
-    - metatomic-ase
-    - rgpycrumbs>=1.7.0,<2
-    - chemparseplot>=1.7.0,<2
+    - metatomic-ase>=0.1.1
+    - metatomic-torch>=0.1.15,<0.2
+    - metatensor-torch>=0.10.0,<0.11
+    - rgpycrumbs>=1.8.0,<2
+    - chemparseplot>=1.8.0,<2
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -12,12 +12,9 @@ dependencies:
     - torch>=2.9,<2.10
     - ase>=3.23
     - matplotlib
-    # Keep mtt export on the same metatomic ABI as conda eon 2.15 until
-    # TheochemUI/eOn#361 is released and the feedstock rebuilds against
-    # libmetatomic-torch 0.1.15 (needs libtorch 2.12 on conda-forge).
     - metatrain>=2026.2.1,<2026.3
     - requests
-    - metatomic-ase>=0.1.1
-    - rgpycrumbs>=1.8.0,<2
-    - chemparseplot>=1.8.0,<2
+    - metatomic-ase
+    - rgpycrumbs==1.8.0
+    - chemparseplot==1.8.0
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -3,13 +3,18 @@ channels:
   - conda-forge
   - https://repo.prefix.dev/rg-forge
 dependencies:
+  # eonclient links libmetatomic-torch; 0.1.15 accepts models from metatrain 2026.3
+  # (sample_kind / optional per_atom). That package requires libtorch >=2.12.
   - eon>=2.15.0
+  - libmetatomic-torch>=0.1.15,<0.2
+  - libmetatensor-torch>=0.10.0,<0.11
+  - libmetatensor>=0.2.2,<0.3
+  - libtorch>=2.12,<2.13
   - ira
   - python=3.13
   - pip
   - uv
   - pip:
-    - torch>=2.9,<2.11
     - ase>=3.23
     - matplotlib
     - metatrain>=2026.3,<2027


### PR DESCRIPTION
## Summary
- Point `examples/eon-pet-neb` at current Metatomic / metatrain and the eOn 2.15+ / rgpycrumbs 1.8 / chemparseplot 1.8 stack.
- Needs an eOn build linked against metatomic-torch >=0.1.15 so `eonclient` accepts models from metatrain 2026.3.
- Companion eOn PR: https://github.com/TheochemUI/eOn/pull/361

## Test plan
- [ ] CI generate-example (eon-pet-neb) green