### PR TITLE
fix(ml-mm): pin metatrain/metatomic to gromacs-metatomic ABI

### DIFF
--- a/examples/ml-mm/environment.yml
+++ b/examples/ml-mm/environment.yml
@@ -22,10 +22,14 @@ dependencies:
   - pip
   - uv
   - pip:
+    # Align Python metatomic stack with published metatensor::gromacs-metatomic
+    # (libmetatomic-torch <0.1.12 on the metatensor channel). Raise metatrain
+    # and metatomic-torch after a feedstock rebuild against metatomic-torch
+    # >=0.1.15 (see metatensor/gromacs#13).
     - torch>=2.7,<2.8
     - ase>=3.23
     - cmcrameri
-    - metatrain
-    - metatomic-torch
+    - metatrain>=2026.2.1,<2026.3
+    - metatomic-torch>=0.1.11,<0.1.12
     - metatomic-ase
     - atomistic-cookbook-utils >=0.1,<0.2


### PR DESCRIPTION
## Summary
- Pin `examples/ml-mm` pip deps to metatrain 2026.2.x and metatomic-torch 0.1.11.x so the Python stack matches published `metatensor::gromacs-metatomic` (libmetatomic-torch &lt;0.1.12).
- Companion GROMACS source fix for the next metatomic client rebuild: https://github.com/metatensor/gromacs/pull/13 (`get_per_atom` / `set_per_atom` for metatomic-torch &gt;=0.1.15).

## Test plan
- [ ] CI generate-example (ml-mm) green
- [ ] Do not merge until maintainers accept pins / feedstock path