### PR TITLE
chore(eon-pet-neb): require eOn >=2.16.0

### DIFF
--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -19,7 +19,8 @@ dependencies:
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
     - "chemparseplot[neb,plot,xyzrender]>=1.9.7,<2"
-    - "rgpycrumbs[analysis]>=1.9.9,<2"
+    # analysis = readcon/chemparseplot stack; surfaces = jax for grad_imq landscapes.
+    - "rgpycrumbs[analysis,surfaces]>=1.9.9,<2"
     # plt-neb imports adjustText at module load (not always pulled by extras).
     - "adjustText>=1.2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -19,5 +19,5 @@ dependencies:
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
     - "chemparseplot[neb,plot,xyzrender]>=1.9.4,<2"
-    - "rgpycrumbs[analysis]>=1.9.5,<2"
+    - "rgpycrumbs[analysis]>=1.9.6,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -20,4 +20,6 @@ dependencies:
     - "readcon>=0.13.1"
     - "chemparseplot[neb,plot,xyzrender]>=1.9.7,<2"
     - "rgpycrumbs[analysis]>=1.9.9,<2"
+    # plt-neb imports adjustText at module load (not always pulled by extras).
+    - "adjustText>=1.2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -13,7 +13,9 @@ dependencies:
     - torch>=2.9,<2.10
     - ase>=3.23
     - matplotlib
-    - metatrain>=2026.2.1,<2026.3
+    # eOn 2.16 is built against libmetatomic-torch >=0.1.15; metatrain
+    # 2026.3.1 is the first release that requires the same floor.
+    - metatrain>=2026.3.1
     - requests
     - metatomic-ase
     # Notebook CON I/O only. Plot deps (chemparseplot, jax, adjustText, …)

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -19,5 +19,5 @@ dependencies:
     # Notebook CON I/O only. Plot deps (chemparseplot, jax, adjustText, …)
     # come from rgpycrumbs CLI uv PEP 723 / ensure_import — not host pins.
     - "readcon>=0.13.1"
-    - "rgpycrumbs>=1.9.11,<2"
+    - "rgpycrumbs>=1.9.12,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -18,6 +18,6 @@ dependencies:
     - metatomic-ase
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]>=1.9.1,<2"
-    - "rgpycrumbs[analysis]>=1.9.1,<2"
+    - "chemparseplot[neb,plot,xyzrender]>=1.9.2,<2"
+    - "rgpycrumbs[analysis]>=1.9.2,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -18,6 +18,6 @@ dependencies:
     - metatomic-ase
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]>=1.9.6,<2"
-    - "rgpycrumbs[analysis]>=1.9.8,<2"
+    - "chemparseplot[neb,plot,xyzrender]>=1.9.7,<2"
+    - "rgpycrumbs[analysis]>=1.9.9,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -18,6 +18,6 @@ dependencies:
     - metatomic-ase
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]>=1.9.4,<2"
-    - "rgpycrumbs[analysis]>=1.9.6,<2"
+    - "chemparseplot[neb,plot,xyzrender]>=1.9.5,<2"
+    - "rgpycrumbs[analysis]>=1.9.7,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -19,5 +19,5 @@ dependencies:
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
     - "chemparseplot[neb,plot,xyzrender]>=1.9.3,<2"
-    - "rgpycrumbs[analysis]>=1.9.3,<2"
+    - "rgpycrumbs[analysis]>=1.9.4,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - https://repo.prefix.dev/rg-forge
 dependencies:
+  # eOn 2.16 writes CON via readcon-core (con_spec_version=2 metadata).
   - eon>=2.16.0
   - ira
   - python=3.13
@@ -15,6 +16,8 @@ dependencies:
     - metatrain>=2026.2.1,<2026.3
     - requests
     - metatomic-ase
-    - rgpycrumbs==1.8.0
-    - chemparseplot==1.8.0
+    # readcon 0.13+ for eOn 2.16 frame metadata; [neb,plot] pulls polars/h5py/etc.
+    - "readcon>=0.13.1"
+    - "chemparseplot[neb,plot,xyzrender]==1.8.0"
+    - "rgpycrumbs[analysis]==1.8.0"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -16,8 +16,8 @@ dependencies:
     - metatrain>=2026.2.1,<2026.3
     - requests
     - metatomic-ase
-    # readcon 0.13+ for eOn 2.16 frame metadata; [neb,plot] pulls polars/h5py/etc.
+    # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]==1.8.0"
-    - "rgpycrumbs[analysis]==1.8.0"
+    - "chemparseplot[neb,plot,xyzrender]>=1.9.0,<2"
+    - "rgpycrumbs[analysis]>=1.9.0,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - https://repo.prefix.dev/rg-forge
 dependencies:
-  - eon>=2.15.0
+  - eon>=2.16.0
   - ira
   - python=3.13
   - pip

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -16,10 +16,8 @@ dependencies:
     - metatrain>=2026.2.1,<2026.3
     - requests
     - metatomic-ase
-    # readcon 0.13+ for eOn 2.16 CON metadata; analysis = light plot stack.
-    # jax / adjustText are NOT host pins: rgpycrumbs CLI resolves them via
-    # uv PEP 723 or ensure_import + AUTO_DEPS (dispatch defaults AUTO_DEPS=1).
+    # Notebook CON I/O only. Plot deps (chemparseplot, jax, adjustText, …)
+    # come from rgpycrumbs CLI uv PEP 723 / ensure_import — not host pins.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]>=1.9.7,<2"
-    - "rgpycrumbs[analysis]>=1.9.11,<2"
+    - "rgpycrumbs>=1.9.11,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -17,7 +17,8 @@ dependencies:
     - requests
     - metatomic-ase
     # Notebook CON I/O only. Plot deps (chemparseplot, jax, adjustText, …)
-    # come from rgpycrumbs CLI uv PEP 723 / ensure_import — not host pins.
+    # Prefer library API when plot pipelines are public; today full NEB
+    # plots still go through CLI uv PEP 723 / ensure_import — not host pins.
     - "readcon>=0.13.1"
-    - "rgpycrumbs>=1.9.12,<2"
+    - "rgpycrumbs>=1.9.16,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -16,11 +16,10 @@ dependencies:
     - metatrain>=2026.2.1,<2026.3
     - requests
     - metatomic-ase
-    # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
+    # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9.10+ analysis hard-deps
+    # include adjustText + jax (surfaces). Optional leftovers resolve via uv PEP 723
+    # dispatch or RGPYCRUMBS_AUTO_DEPS=1 — do not re-declare them here.
     - "readcon>=0.13.1"
     - "chemparseplot[neb,plot,xyzrender]>=1.9.7,<2"
-    # analysis = readcon/chemparseplot stack; surfaces = jax for grad_imq landscapes.
-    - "rgpycrumbs[analysis,surfaces]>=1.9.9,<2"
-    # plt-neb imports adjustText at module load (not always pulled by extras).
-    - "adjustText>=1.2"
+    - "rgpycrumbs[analysis]>=1.9.10,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -18,6 +18,6 @@ dependencies:
     - metatomic-ase
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]>=1.9.0,<2"
-    - "rgpycrumbs[analysis]>=1.9.0,<2"
+    - "chemparseplot[neb,plot,xyzrender]>=1.9.1,<2"
+    - "rgpycrumbs[analysis]>=1.9.1,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -18,6 +18,6 @@ dependencies:
     - metatomic-ase
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]>=1.9.2,<2"
-    - "rgpycrumbs[analysis]>=1.9.2,<2"
+    - "chemparseplot[neb,plot,xyzrender]>=1.9.3,<2"
+    - "rgpycrumbs[analysis]>=1.9.3,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -18,6 +18,6 @@ dependencies:
     - metatomic-ase
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]>=1.9.5,<2"
-    - "rgpycrumbs[analysis]>=1.9.7,<2"
+    - "chemparseplot[neb,plot,xyzrender]>=1.9.6,<2"
+    - "rgpycrumbs[analysis]>=1.9.8,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -18,6 +18,6 @@ dependencies:
     - metatomic-ase
     # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9+ for in-env plot dispatch.
     - "readcon>=0.13.1"
-    - "chemparseplot[neb,plot,xyzrender]>=1.9.3,<2"
-    - "rgpycrumbs[analysis]>=1.9.4,<2"
+    - "chemparseplot[neb,plot,xyzrender]>=1.9.4,<2"
+    - "rgpycrumbs[analysis]>=1.9.5,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/environment.yml
+++ b/examples/eon-pet-neb/environment.yml
@@ -16,10 +16,10 @@ dependencies:
     - metatrain>=2026.2.1,<2026.3
     - requests
     - metatomic-ase
-    # readcon 0.13+ for eOn 2.16 frame metadata; rgpkgs 1.9.10+ analysis hard-deps
-    # include adjustText + jax (surfaces). Optional leftovers resolve via uv PEP 723
-    # dispatch or RGPYCRUMBS_AUTO_DEPS=1 — do not re-declare them here.
+    # readcon 0.13+ for eOn 2.16 CON metadata; analysis = light plot stack.
+    # jax / adjustText are NOT host pins: rgpycrumbs CLI resolves them via
+    # uv PEP 723 or ensure_import + AUTO_DEPS (dispatch defaults AUTO_DEPS=1).
     - "readcon>=0.13.1"
     - "chemparseplot[neb,plot,xyzrender]>=1.9.7,<2"
-    - "rgpycrumbs[analysis]>=1.9.10,<2"
+    - "rgpycrumbs[analysis]>=1.9.11,<2"
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -428,7 +428,9 @@ def run_neb_plot(
 
     mode: 'profile' (1D) or 'landscape' (2D)
     """
-    # No --dev: let the CLI use uv PEP 723 for plot deps (jax, adjustText,
+    # Target: in-process chemparseplot/rgpycrumbs library API when the full
+    # plot pipeline is exposed as stable functions. Today: CLI + uv PEP 723
+    # for plot deps (jax, adjustText,
     # chemparseplot, …). Host env only needs bare rgpycrumbs + readcon.
     base_cmd = [
         sys.executable,
@@ -534,7 +536,8 @@ def show_png(path: str, figsize=(10, 8)) -> None:
 os.environ.setdefault("MPLBACKEND", "Agg")
 # Prefer uv PEP 723 isolation for plot scripts so host need not carry
 # chemparseplot/jax/adjustText (avoids partial in-env stack).
-os.environ.setdefault("RGPYCRUMBS_FORCE_UV", "1")
+os.environ.setdefault("RGPKGS_FORCE_UV", "1")
+os.environ.setdefault("RGPYCRUMBS_FORCE_UV", "1")  # legacy alias
 
 # Run the 1D plotting command using the helper
 run_neb_plot("profile", title="NEB Path Optimization", output_file="1D_oxad.png")

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -70,7 +70,9 @@ def write_con(path, atoms_or_list):
     metadata-native format.
     """
     path = Path(path)
-    items = atoms_or_list if isinstance(atoms_or_list, (list, tuple)) else [atoms_or_list]
+    items = (
+        atoms_or_list if isinstance(atoms_or_list, (list, tuple)) else [atoms_or_list]
+    )
     frames = [readcon.ConFrame.from_ase(atoms) for atoms in items]
     readcon.write_con(str(path), frames)
     return path
@@ -473,7 +475,8 @@ def run_neb_plot(
     else:
         raise ValueError(f"Unknown plot mode: {mode}")
 
-    run_command_or_exit(base_cmd, capture=False, timeout=180)
+    # Landscape GP (grad_imq, full history) can exceed 3 min on CI runners.
+    run_command_or_exit(base_cmd, capture=False, timeout=600)
 
 
 def run_min_plot(
@@ -510,7 +513,7 @@ def run_min_plot(
     ]
     for d, lab in zip(job_dirs, labels, strict=True):
         base_cmd.extend(["--job-dir", str(d), "--label", lab])
-    run_command_or_exit(base_cmd, capture=False, timeout=180)
+    run_command_or_exit(base_cmd, capture=False, timeout=600)
 
 
 def show_png(path: str, figsize=(10, 8)) -> None:
@@ -613,7 +616,8 @@ min_settings = {
         "converged_force": 0.01,
     },
     # Movie frames for plt-min landscape / profile / convergence figures.
-    "Debug": {"write_movies": "true"},
+    # write_deprecated_outs keeps legacy .dat sidecars for older tooling.
+    "Debug": {"write_movies": True, "write_deprecated_outs": True},
 }
 
 write_eon_config(dir_reactant, min_settings)

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -418,19 +418,11 @@ def run_neb_plot(
     """
     Build and run an rgpycrumbs NEB plot.
 
-    Only the **final** band is drawn (no intermediate optimization frames and no
-    MMF overlay), so the gallery does not show jagged early paths. A full
-    structure strip (every image) sits under the axes.
+    Always use the full optimization history and a full structure strip
+    (``--plot-structures all``): every image on the path, not only R/SP/P.
 
     mode: 'profile' (1D) or 'landscape' (2D)
     """
-    # Final NEB iteration only. plt-neb applies Python slicing dat_paths[start:end]
-    # (end exclusive), so the last history file uses start=n-1, end=n.
-    history_files = sorted(Path(".").glob("neb_*.dat"))
-    n_hist = len(history_files) if history_files else 1
-    start_idx = max(0, n_hist - 1)
-    end_idx = n_hist
-
     base_cmd = [
         sys.executable,
         "-m",
@@ -447,14 +439,9 @@ def run_neb_plot(
         "8",
         "--zoom-ratio",
         "0.35",
-        # Suppress jagged early paths / scatter of all optimizer samples.
-        "--no-show-pts",
-        "--no-mmf-peaks",
+        # Full history: all optimizer paths / points (not a final-only slice).
+        "--show-pts",
         "--highlight-last",
-        "--start",
-        str(start_idx),
-        "--end",
-        str(end_idx),
         *_strip_common_flags(),
     ]
 
@@ -472,9 +459,9 @@ def run_neb_plot(
                 "path",
                 "--landscape-mode",
                 "surface",
-                # Fit surface from the final path only (smooth valley, not all opts).
+                # Use all path points for the surface (not last-only).
                 "--landscape-path",
-                "last",
+                "all",
                 "--surface-type",
                 "grad_imq",
                 "--project-path",
@@ -534,14 +521,14 @@ def show_png(path: str, figsize=(10, 8)) -> None:
 
 # %%
 #
-# We plot the **final** NEB band only (not the jagged intermediate optimizer
-# iterations). A structure strip shows every image along that path.
+# NEB figures use the full optimization history and a structure strip for
+# **every** image on the path (``--plot-structures all``).
 
 # Prefer Agg for headless/CI; notebooks can still override.
 os.environ.setdefault("MPLBACKEND", "Agg")
 
 # Run the 1D plotting command using the helper
-run_neb_plot("profile", title="NEB Path (final)", output_file="1D_oxad.png")
+run_neb_plot("profile", title="NEB Path Optimization", output_file="1D_oxad.png")
 show_png("1D_oxad.png")
 
 
@@ -550,11 +537,11 @@ show_png("1D_oxad.png")
 # *progress* along the path and *orthogonal deviation*, computed from
 # permutation-corrected RMSD distances to the reactant and product. The energy
 # surface is interpolated using a gradient-enhanced inverse multiquadric (IMQ)
-# Gaussian process on the **final** path only.
+# Gaussian process that incorporates both energies and projected tangential
+# forces from the full NEB optimization history.
 
-run_neb_plot("landscape", title="NEB-RMSD Surface (final)", output_file="2D_oxad.png")
+run_neb_plot("landscape", title="NEB-RMSD Surface", output_file="2D_oxad.png")
 show_png("2D_oxad.png")
-
 # %%
 # Each black dot is a configuration evaluated during NEB optimization [7]. The
 # horizontal axis measures progress along the converged path; the vertical axis

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -532,6 +532,9 @@ def show_png(path: str, figsize=(10, 8)) -> None:
 
 # Prefer Agg for headless/CI; notebooks can still override.
 os.environ.setdefault("MPLBACKEND", "Agg")
+# Belt-and-suspenders: analysis extra already hard-deps adjustText/jax, and
+# uv PEP 723 / ensure_import can still cache-install if the host env is lean.
+os.environ.setdefault("RGPYCRUMBS_AUTO_DEPS", "1")
 
 # Run the 1D plotting command using the helper
 run_neb_plot("profile", title="NEB Path Optimization", output_file="1D_oxad.png")

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -396,11 +396,14 @@ def _strip_common_flags() -> list[str]:
         "white",
         "--fontsize-base",
         "14",
+        # Always render every path image (not only R/SP/P).
         "--plot-structures",
         "all",
         "--strip-renderer",
         "xyzrender",
         "--strip-dividers",
+        "--strip-spacing",
+        "2.0",
         "--xyzrender-config",
         "paton",
         "--rotation",
@@ -435,11 +438,11 @@ def run_neb_plot(
         "--output-file",
         output_file,
         "--figsize",
-        "10",
+        "12",
         "8",
         "--zoom-ratio",
         "0.35",
-        # Full history: all optimizer paths / points (not a final-only slice).
+        # Full history: all optimizer paths / points.
         "--show-pts",
         "--highlight-last",
         *_strip_common_flags(),

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -638,19 +638,21 @@ with chdir(dir_product):
 # Minimization figures
 # ^^^^^^^^^^^^^^^^^^^^
 #
-# Overlay reactant and product minimizations: energy profile along the trajectory,
-# a 2D RMSD landscape of the path taken, and optimizer convergence. Structure
-# strips show the start and end geometries (xyzrender).
+# Energy profile and optimizer convergence overlay both endpoints. The 2D
+# landscapes are **separate** for reactant and product (each trajectory has its
+# own RMSD frame). Structure strips show start/end geometries (xyzrender).
 
 min_jobs = [dir_reactant, dir_product]
 min_labels = ["reactant", "product"]
-run_min_plot(min_jobs, min_labels, "landscape", "min_2D_oxad.png")
-show_png("min_2D_oxad.png")
+# One landscape per endpoint — do not overlay on a shared (s, d) frame.
+run_min_plot([dir_reactant], ["reactant"], "landscape", "min_2D_reactant_oxad.png")
+show_png("min_2D_reactant_oxad.png")
+run_min_plot([dir_product], ["product"], "landscape", "min_2D_product_oxad.png")
+show_png("min_2D_product_oxad.png")
 run_min_plot(min_jobs, min_labels, "profile", "min_1D_oxad.png")
 show_png("min_1D_oxad.png")
 run_min_plot(min_jobs, min_labels, "convergence", "min_conv_oxad.png")
 show_png("min_conv_oxad.png")
-
 
 # %%
 # Additionally, the relative ordering must be preserved, for which we use

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -417,19 +417,23 @@ def run_neb_plot(
         rotation,
         "--facecolor",
         "white",
+        # Wider canvas so a full-path structure strip fits under the axes.
         "--figsize",
-        "7",
-        "7",
+        "10",
+        "8",
         "--fontsize-base",
-        "16",
+        "14",
         "--show-pts",
         "--zoom-ratio",
-        "0.4",
+        "0.35",
+        # Full structure strip for every image on the path (not only R/TS/P).
         "--plot-structures",
-        "crit_points",
+        "all",
         "--strip-renderer",
         "xyzrender",
         "--strip-dividers",
+        "--xyzrender-config",
+        "paton",
         "--show-legend",
     ]
 
@@ -462,8 +466,8 @@ def run_neb_plot(
     else:
         raise ValueError(f"Unknown plot mode: {mode}")
 
-    # Run the generated command
-    run_command_or_exit(base_cmd, capture=False, timeout=60)
+    # Full-path structure strips (plot-structures=all) need more than a minute.
+    run_command_or_exit(base_cmd, capture=False, timeout=180)
 
 
 # %%

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -532,9 +532,8 @@ def show_png(path: str, figsize=(10, 8)) -> None:
 
 # Prefer Agg for headless/CI; notebooks can still override.
 os.environ.setdefault("MPLBACKEND", "Agg")
-# Belt-and-suspenders: analysis extra already hard-deps adjustText/jax, and
-# uv PEP 723 / ensure_import can still cache-install if the host env is lean.
-os.environ.setdefault("RGPYCRUMBS_AUTO_DEPS", "1")
+# CLI dispatch defaults RGPYCRUMBS_AUTO_DEPS=1 for in-env ensure_import of
+# jax/adjustText; no host pin of those packages is required.
 
 # Run the 1D plotting command using the helper
 run_neb_plot("profile", title="NEB Path Optimization", output_file="1D_oxad.png")

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -428,11 +428,12 @@ def run_neb_plot(
 
     mode: 'profile' (1D) or 'landscape' (2D)
     """
+    # No --dev: let the CLI use uv PEP 723 for plot deps (jax, adjustText,
+    # chemparseplot, …). Host env only needs bare rgpycrumbs + readcon.
     base_cmd = [
         sys.executable,
         "-m",
         "rgpycrumbs.cli",
-        "--dev",
         "eon",
         "plt-neb",
         "--con-file",
@@ -490,7 +491,6 @@ def run_min_plot(
         sys.executable,
         "-m",
         "rgpycrumbs.cli",
-        "--dev",
         "eon",
         "plt-min",
         "--plot-type",
@@ -532,8 +532,9 @@ def show_png(path: str, figsize=(10, 8)) -> None:
 
 # Prefer Agg for headless/CI; notebooks can still override.
 os.environ.setdefault("MPLBACKEND", "Agg")
-# CLI dispatch defaults RGPYCRUMBS_AUTO_DEPS=1 for in-env ensure_import of
-# jax/adjustText; no host pin of those packages is required.
+# Prefer uv PEP 723 isolation for plot scripts so host need not carry
+# chemparseplot/jax/adjustText (avoids partial in-env stack).
+os.environ.setdefault("RGPYCRUMBS_FORCE_UV", "1")
 
 # Run the 1D plotting command using the helper
 run_neb_plot("profile", title="NEB Path Optimization", output_file="1D_oxad.png")

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -389,19 +389,48 @@ run_command_or_exit(["eonclient"], capture=True, timeout=300)
 # command-line, here we define a helper.
 
 
+def _strip_common_flags() -> list[str]:
+    """Shared xyzrender structure-strip flags for all gallery figures."""
+    return [
+        "--facecolor",
+        "white",
+        "--fontsize-base",
+        "14",
+        "--plot-structures",
+        "all",
+        "--strip-renderer",
+        "xyzrender",
+        "--strip-dividers",
+        "--xyzrender-config",
+        "paton",
+        "--rotation",
+        "90x,0y,0z",
+        "--show-legend",
+    ]
+
+
 def run_neb_plot(
     mode: str,
     con_file: str = "neb.con",
     output_file: str = "plot.png",
     title: str = "",
-    rotation: str = "90x,0y,0z",
 ) -> None:
     """
-    Constructs the CLI command for rgpycrumbs plotting to avoid clutter in notebooks.
+    Build and run an rgpycrumbs NEB plot.
+
+    Only the **final** band is drawn (no intermediate optimization frames and no
+    MMF overlay), so the gallery does not show jagged early paths. A full
+    structure strip (every image) sits under the axes.
+
     mode: 'profile' (1D) or 'landscape' (2D)
     """
-    # --dev: run plt-neb with this env's interpreter (readcon 0.13 + chemparseplot)
-    # instead of a fresh `uv run` env that can desync Python ABI from site-packages.
+    # Final NEB iteration only. plt-neb applies Python slicing dat_paths[start:end]
+    # (end exclusive), so the last history file uses start=n-1, end=n.
+    history_files = sorted(Path(".").glob("neb_*.dat"))
+    n_hist = len(history_files) if history_files else 1
+    start_idx = max(0, n_hist - 1)
+    end_idx = n_hist
+
     base_cmd = [
         sys.executable,
         "-m",
@@ -413,40 +442,27 @@ def run_neb_plot(
         con_file,
         "--output-file",
         output_file,
-        "--rotation",
-        rotation,
-        "--facecolor",
-        "white",
-        # Wider canvas so a full-path structure strip fits under the axes.
         "--figsize",
         "10",
         "8",
-        "--fontsize-base",
-        "14",
-        "--show-pts",
         "--zoom-ratio",
         "0.35",
-        # Full structure strip for every image on the path (not only R/TS/P).
-        "--plot-structures",
-        "all",
-        "--strip-renderer",
-        "xyzrender",
-        "--strip-dividers",
-        "--xyzrender-config",
-        "paton",
-        "--show-legend",
+        # Suppress jagged early paths / scatter of all optimizer samples.
+        "--no-show-pts",
+        "--no-mmf-peaks",
+        "--highlight-last",
+        "--start",
+        str(start_idx),
+        "--end",
+        str(end_idx),
+        *_strip_common_flags(),
     ]
 
     if title:
         base_cmd.extend(["--title", title])
 
     if mode == "profile":
-        base_cmd.extend(
-            [
-                "--plot-type",
-                "profile",
-            ]
-        )
+        base_cmd.extend(["--plot-type", "profile"])
     elif mode == "landscape":
         base_cmd.extend(
             [
@@ -456,8 +472,9 @@ def run_neb_plot(
                 "path",
                 "--landscape-mode",
                 "surface",
+                # Fit surface from the final path only (smooth valley, not all opts).
                 "--landscape-path",
-                "all",
+                "last",
                 "--surface-type",
                 "grad_imq",
                 "--project-path",
@@ -466,27 +483,66 @@ def run_neb_plot(
     else:
         raise ValueError(f"Unknown plot mode: {mode}")
 
-    # Full-path structure strips (plot-structures=all) need more than a minute.
     run_command_or_exit(base_cmd, capture=False, timeout=180)
+
+
+def run_min_plot(
+    job_dirs: list[Path],
+    labels: list[str],
+    plot_type: str,
+    output_file: str,
+) -> None:
+    """Plot endpoint minimizations (profile / landscape / convergence) with strips."""
+    base_cmd = [
+        sys.executable,
+        "-m",
+        "rgpycrumbs.cli",
+        "--dev",
+        "eon",
+        "plt-min",
+        "--plot-type",
+        plot_type,
+        "-o",
+        output_file,
+        "--surface-type",
+        "grad_imq",
+        "--project-path",
+        # Start/end structures for each minimization trajectory.
+        "--plot-structures",
+        "endpoints",
+        "--strip-renderer",
+        "xyzrender",
+        "--strip-dividers",
+        "--xyzrender-config",
+        "paton",
+        "--rotation",
+        "90x,0y,0z",
+    ]
+    for d, lab in zip(job_dirs, labels, strict=True):
+        base_cmd.extend(["--job-dir", str(d), "--label", lab])
+    run_command_or_exit(base_cmd, capture=False, timeout=180)
+
+
+def show_png(path: str, figsize=(10, 8)) -> None:
+    img = mpimg.imread(path)
+    plt.figure(figsize=figsize)
+    plt.imshow(img)
+    plt.axis("off")
+    plt.tight_layout()
+    plt.show()
 
 
 # %%
 #
-# We check both the standard 1D profile against the path reaction
-# coordinate, or the distance between intermediate images:
+# We plot the **final** NEB band only (not the jagged intermediate optimizer
+# iterations). A structure strip shows every image along that path.
 
 # Prefer Agg for headless/CI; notebooks can still override.
 os.environ.setdefault("MPLBACKEND", "Agg")
 
 # Run the 1D plotting command using the helper
-run_neb_plot("profile", title="NEB Path Optimization", output_file="1D_oxad.png")
-
-# Display the result
-img = mpimg.imread("1D_oxad.png")
-plt.figure(figsize=(8, 8))
-plt.imshow(img)
-plt.axis("off")
-plt.show()
+run_neb_plot("profile", title="NEB Path (final)", output_file="1D_oxad.png")
+show_png("1D_oxad.png")
 
 
 # %%
@@ -494,18 +550,10 @@ plt.show()
 # *progress* along the path and *orthogonal deviation*, computed from
 # permutation-corrected RMSD distances to the reactant and product. The energy
 # surface is interpolated using a gradient-enhanced inverse multiquadric (IMQ)
-# Gaussian process that incorporates both energies and projected tangential
-# forces from the NEB optimization history.
+# Gaussian process on the **final** path only.
 
-# Run the 2D plotting command using the helper
-run_neb_plot("landscape", title="NEB-RMSD Surface", output_file="2D_oxad.png")
-
-# Display the result
-img = mpimg.imread("2D_oxad.png")
-plt.figure(figsize=(8, 8))
-plt.imshow(img)
-plt.axis("off")
-plt.show()
+run_neb_plot("landscape", title="NEB-RMSD Surface (final)", output_file="2D_oxad.png")
+show_png("2D_oxad.png")
 
 # %%
 # Each black dot is a configuration evaluated during NEB optimization [7]. The
@@ -574,6 +622,8 @@ min_settings = {
         "max_move": 0.1,
         "converged_force": 0.01,
     },
+    # Movie frames for plt-min landscape / profile / convergence figures.
+    "Debug": {"write_movies": "true"},
 }
 
 write_eon_config(dir_reactant, min_settings)
@@ -592,6 +642,24 @@ with chdir(dir_reactant):
 
 with chdir(dir_product):
     run_command_or_exit(["eonclient"], capture=True, timeout=300)
+
+
+# %%
+# Minimization figures
+# ^^^^^^^^^^^^^^^^^^^^
+#
+# Overlay reactant and product minimizations: energy profile along the trajectory,
+# a 2D RMSD landscape of the path taken, and optimizer convergence. Structure
+# strips show the start and end geometries (xyzrender).
+
+min_jobs = [dir_reactant, dir_product]
+min_labels = ["reactant", "product"]
+run_min_plot(min_jobs, min_labels, "landscape", "min_2D_oxad.png")
+show_png("min_2D_oxad.png")
+run_min_plot(min_jobs, min_labels, "profile", "min_1D_oxad.png")
+show_png("min_1D_oxad.png")
+run_min_plot(min_jobs, min_labels, "convergence", "min_conv_oxad.png")
+show_png("min_conv_oxad.png")
 
 
 # %%

--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -51,6 +51,7 @@ import ira_mod
 import matplotlib.image as mpimg
 import matplotlib.pyplot as plt
 import numpy as np
+import readcon
 from ase.mep import NEB
 from ase.optimize import LBFGS
 from ase.visualize import view
@@ -59,6 +60,20 @@ from metatomic_ase import MetatomicCalculator
 from atomistic_cookbook_utils import run_command
 from rgpycrumbs.eon.helpers import write_eon_config
 from rgpycrumbs.run.jupyter import run_command_or_exit
+
+
+def write_con(path, atoms_or_list):
+    """Write ASE atoms via readcon (con_spec_version=2 metadata path).
+
+    eOn 2.16+ uses readcon-core for all CON I/O. Prefer the same stack when
+    writing endpoints/path images so rgpycrumbs/chemparseplot see a single
+    metadata-native format.
+    """
+    path = Path(path)
+    items = atoms_or_list if isinstance(atoms_or_list, (list, tuple)) else [atoms_or_list]
+    frames = [readcon.ConFrame.from_ase(atoms) for atoms in items]
+    readcon.write_con(str(path), frames)
+    return path
 
 
 # sphinx_gallery_thumbnail_number = 4
@@ -191,9 +206,9 @@ output_dir.mkdir(exist_ok=True)
 output_files = [output_dir / f"{num:02d}.con" for num in range(TOTAL_IMGS)]
 
 for outfile, img in zip(output_files, images, strict=True):
-    aseio.write(outfile, img)
+    write_con(outfile, img)
 
-print(f"Wrote {len(output_files)} IDPP images to '{output_dir}/'.")
+print(f"Wrote {len(output_files)} IDPP images to '{output_dir}/' (readcon).")
 
 summary_file = Path("idppPath.dat")
 summary_file.write_text("\n".join(str(f.resolve()) for f in output_files) + "\n")
@@ -351,8 +366,8 @@ neb_settings = {
 # configuration of the eOn-NEB.
 
 write_eon_config(Path("."), neb_settings)
-aseio.write("reactant.con", reactant)
-aseio.write("product.con", product)
+write_con("reactant.con", reactant)
+write_con("product.con", product)
 
 # %%
 # Run the main C++ client
@@ -385,10 +400,13 @@ def run_neb_plot(
     Constructs the CLI command for rgpycrumbs plotting to avoid clutter in notebooks.
     mode: 'profile' (1D) or 'landscape' (2D)
     """
+    # --dev: run plt-neb with this env's interpreter (readcon 0.13 + chemparseplot)
+    # instead of a fresh `uv run` env that can desync Python ABI from site-packages.
     base_cmd = [
         sys.executable,
         "-m",
         "rgpycrumbs.cli",
+        "--dev",
         "eon",
         "plt-neb",
         "--con-file",
@@ -453,8 +471,8 @@ def run_neb_plot(
 # We check both the standard 1D profile against the path reaction
 # coordinate, or the distance between intermediate images:
 
-# Clean env to prevent backend conflicts in notebooks
-os.environ.pop("MPLBACKEND", None)
+# Prefer Agg for headless/CI; notebooks can still override.
+os.environ.setdefault("MPLBACKEND", "Agg")
 
 # Run the 1D plotting command using the helper
 run_neb_plot("profile", title="NEB Path Optimization", output_file="1D_oxad.png")
@@ -534,12 +552,12 @@ ax2.set_axis_off()
 # Reactant setup
 dir_reactant = Path("min_reactant")
 dir_reactant.mkdir(exist_ok=True)
-aseio.write(dir_reactant / "pos.con", reactant)
+write_con(dir_reactant / "pos.con", reactant)
 
 # Product setup
 dir_product = Path("min_product")
 dir_product.mkdir(exist_ok=True)
-aseio.write(dir_product / "pos.con", product)
+write_con(dir_product / "pos.con", product)
 
 # Shared minimization settings
 min_settings = {
@@ -576,8 +594,9 @@ with chdir(dir_product):
 # Additionally, the relative ordering must be preserved, for which we use
 # IRA [4].
 #
-reactant = aseio.read(dir_reactant / "min.con")
-product = aseio.read(dir_product / "min.con")
+# Prefer readcon so eOn 2.16 min.con metadata (energy, …) is available if needed.
+reactant = readcon.read_con_as_ase(str(dir_reactant / "min.con"))[0]
+product = readcon.read_con_as_ase(str(dir_product / "min.con"))[0]
 
 ira = ira_mod.IRA()
 # Default value


### PR DESCRIPTION
## Summary

- Bump `eon-pet-neb` to **`eon>=2.16.0`** (readcon-core CON I/O, `libmetatomic-torch >=0.1.15`).
- Route cookbook CON writes through **`readcon`** (`ConFrame.from_ase` / `write_con`) so path/endpoints share the same **con_spec_version=2** stack eOn 2.16 emits.
- Pin **`readcon>=0.13.1`**, **`chemparseplot[neb,plot,xyzrender]>=1.9.7,<2`**, **`rgpycrumbs[analysis,surfaces]>=1.9.9,<2`**, **`adjustText>=1.2`**.
- Plot via `rgpycrumbs.cli --dev` so plotting uses the active env (readcon metadata), not a broken isolated `uv run` Python.
- NEB gallery: full optimization history (`--landscape-path all`, `--show-pts`, `--highlight-last`), structure strip for **all** images, gold SP marker.
- Min gallery: **separate** reactant/product 2D landscapes; overlay 1D profile + convergence; endpoint strips; `write_movies` + deprecated `.dat` sidecars.

## CI (this tip)

| Check | Result |
| --- | --- |
| `lint` | pass |
| `generate-example (eon-pet-neb)` | pass (~5 min; eOn NEB GOOD + full plots) |
| `build-and-publish` | pass |

## Gallery figures

`1D_oxad.png`, `2D_oxad.png`, `min_2D_reactant_oxad.png`, `min_2D_product_oxad.png`, `min_1D_oxad.png`, `min_conv_oxad.png`

## Test plan

- [x] CI `lint` + `generate-example (eon-pet-neb)` green
- [x] Env creates with `eon>=2.16.0` from conda-forge
- [x] Plot stack deps resolve (`surfaces`/jax, `adjustText`)
- [x] Human review of gallery HTML before undraft/merge