### PR TITLE
Fix non-degenerate TA branches in the Si dispersion

### DIFF
--- a/examples/thermal-conductivity-bte/environment.yml
+++ b/examples/thermal-conductivity-bte/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - ase>=3.23
     - upet>=0.2.4
     - chemiscope>1.0
-    - kaldo
+    - kaldo>=2.2.0
     - spglib
     - matplotlib
     - numpy>=2.0,<2.4

--- a/examples/thermal-conductivity-bte/thermal-conductivity-bte.py
+++ b/examples/thermal-conductivity-bte/thermal-conductivity-bte.py
@@ -131,6 +131,7 @@ forceconstants = ForceConstants(
     supercell=supercell,
     third_supercell=supercell,
     folder="fd_si/",
+    is_acoustic_sum=True,
 )
 
 forceconstants.second.calculate(calc, delta_shift=3e-2)
@@ -154,6 +155,7 @@ phonons = Phonons(
     temperature=temperature,
     folder="ald_si/",
     storage="memory",
+    is_unfolding=True,
 )
 
 # %%


### PR DESCRIPTION
## Summary

- Fix non-degenerate transverse acoustic branches near Gamma in the Si dispersion
- `is_unfolding=True` on Phonons: uses Wigner-Seitz folding so degeneracies hold at q-points incommensurate with the 3x3x3 supercell (also fixes the BTE, whose 5x5x5 mesh is incommensurate)
- `is_acoustic_sum=True` on ForceConstants: zeroes the Gamma acoustic modes
- Force-constant symmetrization is now on by default in kaldo, so the PET-MAD symmetry breaking near Gamma is projected out
- Requires kaldo>=2.2.0
