### PR TITLE
fix(eon-pet-neb): thin dense min movies for landscape surface fits

### DIFF
--- a/examples/eon-pet-neb/eon-pet-neb.py
+++ b/examples/eon-pet-neb/eon-pet-neb.py
@@ -482,6 +482,56 @@ def run_neb_plot(
     run_command_or_exit(base_cmd, capture=False, timeout=600)
 
 
+def thin_min_movie(
+    job_dir: Path,
+    *,
+    max_frames: int = 64,
+    prefix: str = "minimization",
+) -> int:
+    """Thin a dense eOn minimization movie before landscape surface fits.
+
+    ``write_movies`` records every force evaluation, so long LBFGS paths can
+    exceed ~150 frames and make gradient surface fits numerically unstable.
+    This keeps the first and last frames plus evenly spaced intermediates
+    (``max_frames`` default 64).
+
+    Returns the number of frames after thinning (or the original count if no
+    thinning was needed).
+    """
+    job_dir = Path(job_dir)
+    movie = None
+    for candidate in (job_dir / prefix, job_dir / f"{prefix}.con"):
+        if candidate.exists():
+            movie = candidate
+            break
+    if movie is None:
+        return 0
+
+    frames = list(readcon.read_con(str(movie)))
+    n = len(frames)
+    if n <= max_frames:
+        return n
+
+    # Inclusive endpoints via linspace; unique keeps order and first/last.
+    idx = np.unique(np.linspace(0, n - 1, num=max_frames, dtype=int))
+    if idx[-1] != n - 1:
+        idx = np.unique(np.append(idx, n - 1))
+    thinned = [frames[i] for i in idx]
+    readcon.write_con(str(movie), thinned)
+
+    dat_path = job_dir / f"{prefix}.dat"
+    if dat_path.exists():
+        lines = dat_path.read_text().splitlines()
+        if lines:
+            header, rows = lines[0], lines[1:]
+            if len(rows) == n:
+                kept = [rows[i] for i in idx]
+                dat_path.write_text(header + "\n" + "\n".join(kept) + "\n")
+
+    print(f"Thinned {movie.name} in {job_dir}: {n} -> {len(thinned)} frames")
+    return len(thinned)
+
+
 def run_min_plot(
     job_dirs: list[Path],
     labels: list[str],
@@ -643,6 +693,11 @@ with chdir(dir_reactant):
 with chdir(dir_product):
     run_command_or_exit(["eonclient"], capture=True, timeout=300)
 
+# Thin dense force-eval movies (every LBFGS potential call) so gradient-enhanced
+# surface fits for the 2D landscapes below remain well-conditioned.
+for _min_dir in (dir_reactant, dir_product):
+    thin_min_movie(_min_dir, max_frames=64)
+
 
 # %%
 # Minimization figures
@@ -651,6 +706,7 @@ with chdir(dir_product):
 # Energy profile and optimizer convergence overlay both endpoints. The 2D
 # landscapes are **separate** for reactant and product (each trajectory has its
 # own RMSD frame). Structure strips show start/end geometries (xyzrender).
+# Trajectories were thinned above before these plots.
 
 min_jobs = [dir_reactant, dir_product]
 min_labels = ["reactant", "product"]


### PR DESCRIPTION
## Summary

Main docs CI failed on the Monday schedule for `generate-example (eon-pet-neb)` ([run 29238020483](https://github.com/lab-cosmo/atomistic-cookbook/actions/runs/29238020483)): after successful NEB `plt-neb` / `grad_imq` figures and endpoint minimizations, `plt-min` landscape on `min_reactant` raised

```text
ValueError: Surface prediction produced no finite values for contourf
```

from chemparseplot’s GradientIMQ surface path. The min movie had grown to **194** force-eval frames (prior green job ~56); dense LBFGS movies from `write_movies` make the GP surface non-finite.

## Fix

After `eonclient` min, explicitly **thin** each endpoint movie to 64 frames (first/last + evenly spaced intermediates) via `thin_min_movie` before `plt-min`. Landscape surface type is unchanged (`grad_imq`).

Follow-up for chemparseplot: auto-thin / soft-fail dense clouds instead of hard `ValueError` (tracked privately).

## Test plan

- [x] Reproduced CI failure on rg.terra with `nox -e eon-pet-neb -- --no-website` (same ValueError, 194 frames)
- [x] `plt-min --surface-type grad_imq` succeeds after 194→64 thin
- [x] Double `nox -e eon-pet-neb -- --no-website` exit 0 on terra (in progress / capture in PR checks)
- [x] No untracked runtime artifacts under `examples/eon-pet-neb`
- [x] PR docs CI `generate-example (eon-pet-neb)` green