### PR TITLE
bosons-fermions-pimd: energies in ℏω₀ + note the propagator requirement

### DIFF
--- a/examples/bosons-fermions-pimd/bosons-fermions-pimd.py
+++ b/examples/bosons-fermions-pimd/bosons-fermions-pimd.py
@@ -68,6 +68,13 @@ from data import analysis, plots
 # quadratic-scaling algorithm of Hirshberg *et al.*
 # (`PNAS 2019 <https://doi.org/10.1073/pnas.1913365116>`_) and Feldman &
 # Hirshberg (`JCP 2023 <https://doi.org/10.1063/5.0173749>`_).
+#
+# .. note::
+#    **Bosons require** ``propagator='bab'``. i-PI's *default* free ring-polymer
+#    propagator is the ``exact`` normal-mode propagator, but bosonic exchange is
+#    implemented only for the Cartesian ``bab`` (Verlet-type) propagator -- pairing
+#    ``<bosons>`` with the ``exact`` or ``cayley`` propagator raises an error. This
+#    is why every input in this tutorial sets ``propagator='bab'`` explicitly.
 
 
 # %%
@@ -239,8 +246,8 @@ switch_err = [e for _, e in switch]
 switch_ref = [analysis.mixture_energy(nb, nd, T_SWITCH) for _, _, (nb, nd) in cases]
 for (name, _, _), m, e, ref in zip(cases, switch_sim, switch_err, switch_ref):
     print(
-        f"{name:20s} (T = {T_SWITCH:.1f} K): PIMD {m * 1e3:.3f} +/- {e * 1e3:.3f} mHa  "
-        f"exact {ref * 1e3:.3f} mHa"
+        f"{name:20s} (T = {T_SWITCH:.1f} K): "
+        f"PIMD {m / omega0:.3f} +/- {e / omega0:.3f}  exact {ref / omega0:.3f}  (E/hw0)"
     )
 
 # %%
@@ -296,7 +303,8 @@ plots.plot_statistics_levels(
 #
 # .. note::
 #    **The exact reference value.** The exact three-fermion energy at 30 K is
-#    **1.053 mHa**, computed by ``analysis.analytical_energy`` from the canonical
+#    :math:`9.55\,\hbar\omega_0` (1.053 mHa), computed by
+#    ``analysis.analytical_energy`` from the canonical
 #    partition-function recursion. Note the Pauli exclusion principle lifts the
 #    fermionic ground state to :math:`6.5\,\hbar\omega_0`, well above the bosonic
 #    :math:`4.5\,\hbar\omega_0`.
@@ -324,16 +332,19 @@ fer_mean, fer_err, n_eff = analysis.weighted_average(E, W)
 fer_traj = np.array(E)
 fer_ref = analysis.analytical_energy(30.0, "fermionic")
 
+# energies in hbar*omega0, to match the figures
+e_hw, err_hw, ref_hw = fer_mean / omega0, fer_err / omega0, fer_ref / omega0
 print("Three fermions (T = 30 K, 8 short trajectories)")
 print(f"  average sign <s>          : {np.mean(signs):.3f}")
-print(f"  fermionic energy          : {fer_mean * 1e3:.3f} +/- {fer_err * 1e3:.3f} mHa")
-print(f"  exact                     : {fer_ref * 1e3:.3f} mHa")
+print(f"  fermionic energy          : {e_hw:.3f} +/- {err_hw:.3f} hw0")
+print(f"  exact                     : {ref_hw:.3f} hw0")
 print(f"  effective sample size     : n_eff = {n_eff:.1f} of 8")
 
 # %%
-# The 8-trajectory fermionic energy brackets the exact 1.053 mHa within its error
-# bar. The individual trajectories (grey) scatter around the mean
-# (blue, with its error bar), which sits on the exact value.
+# The 8-trajectory fermionic energy brackets the exact
+# :math:`9.55\,\hbar\omega_0` within its error bar. The individual trajectories
+# (grey) scatter around the mean (blue, with its error bar), which sits on the
+# exact value.
 
 plots.plot_fermion_ensemble(fer_traj, fer_mean, fer_err, fer_ref)
 

--- a/examples/bosons-fermions-pimd/data/analysis.py
+++ b/examples/bosons-fermions-pimd/data/analysis.py
@@ -91,6 +91,9 @@ def block_average(series, n_blocks=10):
     time the block means are approximately independent, and the standard error
     is their spread, ``std(block_means)/sqrt(n_blocks)``.
 
+    ``n_blocks=10`` was chosen once from a block-averaging convergence check
+    (blocks comfortably longer than the autocorrelation time) and is kept fixed.
+
     Returns ``(mean, error)``.
     """
     series = np.asarray(series, dtype=float)

--- a/examples/bosons-fermions-pimd/data/plots.py
+++ b/examples/bosons-fermions-pimd/data/plots.py
@@ -67,9 +67,10 @@ def plot_statistics_levels(labels, sim, err, ref, title):
     """Energy-level comparison at one temperature: the exact total energy of each
     case is drawn as a horizontal level, with the PIMD value (point + error bar)
     on it. Ordered low to high, this shows how exchange orders the energies."""
-    sim = np.array(sim) * 1e3
-    err = np.array(err) * 1e3
-    ref = np.array(ref) * 1e3
+    omega0 = analysis.omega0()
+    sim = np.array(sim) / omega0
+    err = np.array(err) / omega0
+    ref = np.array(ref) / omega0
     fig, ax = plt.subplots(figsize=(6, 4), constrained_layout=True)
     for i, lab in enumerate(labels):
         ax.hlines(ref[i], i + 0.15, i + 0.85, color="gray", lw=2.5)
@@ -85,7 +86,7 @@ def plot_statistics_levels(labels, sim, err, ref, title):
     ax.set_xlim(0, len(labels))
     ax.plot([], [], color="gray", lw=2.5, label="exact")
     ax.plot([], [], "o", color="C0", label="PIMD")
-    ax.set_ylabel("total energy / mHa")
+    ax.set_ylabel(r"total energy $/\,\hbar\omega_0$")
     ax.set_title(title)
     ax.legend(loc="upper left")
     return ax
@@ -94,15 +95,21 @@ def plot_statistics_levels(labels, sim, err, ref, title):
 def plot_fermion_ensemble(traj_energies, mean, err, exact):
     """One-run-vs-many fermion picture: scattered per-trajectory energies (grey)
     and the sign-weighted mean with its error bar (blue), against the exact line."""
+    omega0 = analysis.omega0()
     traj = np.asarray(traj_energies)
     n = len(traj)
     jitter = 0.15 * (np.arange(n) - (n - 1) / 2) / max((n - 1) / 2, 1)
 
     fig, ax = plt.subplots(figsize=(6, 4), constrained_layout=True)
-    ax.axhline(exact * 1e3, color="k", ls="--", label=f"exact ({exact * 1e3:.3f} mHa)")
+    ax.axhline(
+        exact / omega0,
+        color="k",
+        ls="--",
+        label=rf"exact ({exact / omega0:.2f}$\,\hbar\omega_0$)",
+    )
     ax.plot(
         jitter,
-        traj * 1e3,
+        traj / omega0,
         "o",
         color="gray",
         alpha=0.6,
@@ -110,8 +117,8 @@ def plot_fermion_ensemble(traj_energies, mean, err, exact):
     )
     ax.errorbar(
         [0],
-        [mean * 1e3],
-        yerr=[err * 1e3],
+        [mean / omega0],
+        yerr=[err / omega0],
         fmt="s",
         color="C0",
         ms=9,
@@ -120,7 +127,7 @@ def plot_fermion_ensemble(traj_energies, mean, err, exact):
     )
     ax.set_xlim(-1, 1)
     ax.set_xticks([])
-    ax.set_ylabel("fermionic total energy / mHa")
+    ax.set_ylabel(r"fermionic total energy $/\,\hbar\omega_0$")
     ax.set_title("Three fermions at 30 K: one run vs. eight")
     ax.legend()
     return ax
@@ -133,15 +140,16 @@ def plot_sign_scatter(cases):
     ``cases`` is a list of ``(label, traj_energies_Ha, exact_Ha)``. Each is drawn
     as a jittered column of grey points with a dashed line at its exact value.
     """
+    omega0 = analysis.omega0()
     fig, ax = plt.subplots(figsize=(6, 4), constrained_layout=True)
     for x, (_label, traj, exact) in enumerate(cases):
-        traj = np.asarray(traj) * 1e3
+        traj = np.asarray(traj) / omega0
         n = len(traj)
         jitter = x + 0.12 * (np.arange(n) - (n - 1) / 2) / max((n - 1) / 2, 1)
         ax.plot(jitter, traj, "o", color="gray", alpha=0.6)
-        ax.hlines(exact * 1e3, x - 0.28, x + 0.28, color="k", ls="--")
+        ax.hlines(exact / omega0, x - 0.28, x + 0.28, color="k", ls="--")
     ax.set_xticks(range(len(cases)), [c[0] for c in cases])
-    ax.set_ylabel("per-trajectory energy / mHa")
+    ax.set_ylabel(r"per-trajectory energy $/\,\hbar\omega_0$")
     ax.set_title("The sign problem: colder = much wider scatter")
     ax.text(
         0.98,


### PR DESCRIPTION
Small follow-up to #292 (merged) — three consistency fixes to the
bosons/fermions PIMD example:

1. **Report all energies in ℏω₀.** The switching, fermion-ensemble and
   sign-scatter figures (and the switching/fermion printouts) were in mHa while
   the boson E(T) curve was already in ℏω₀; now every panel and printout is
   directly comparable. The recognizable 1.053 mHa fermion benchmark is kept
   parenthetically (= 9.55 ℏω₀).
2. **Note that bosons require `propagator='bab'`.** i-PI's default free
   ring-polymer propagator is `exact`, but bosonic exchange is only implemented
   for the `bab` propagator (`exact`/`cayley` raise an error with `<bosons>`) —
   worth stating so readers who edit inputs aren't surprised.
3. **Document the `block_average` block count** (chosen once from a
   block-averaging convergence check).

No behaviour change beyond units. Lint clean (flake8 `--max-line-length=88`,
ruff, blackdoc).
