### PR TITLE
fix(metatomic-plumed): pin engines to published 2.10.1.dev1 / mta1

### DIFF
--- a/examples/metatomic-plumed/environment.yml
+++ b/examples/metatomic-plumed/environment.yml
@@ -2,23 +2,21 @@ channels:
   - metatensor
   - conda-forge
 dependencies:
-  - python=3.13
+  - python=3.12
   - pip
-  - plumed-metatomic
-  - py-plumed-metatomic
-  - lammps-metatomic
+  - plumed-metatomic=2.10.1.dev1
+  - py-plumed-metatomic=2.10.1.dev1
+  - lammps-metatomic=2026.07.04.mta1
   - matplotlib
-  - libtorch==2.9.1
-  - libmetatomic-torch==0.1.7
   - pip:
     - --extra-index-url https://download.pytorch.org/whl/cpu
-    - torch==2.9.1
+    - torch>=2.12,<2.13
     - ase
     - numpy
     - chemiscope>=1.0
     - ipi>=3.2.0
-    - metatomic-torch==0.1.7
-    - featomic-torch
+    - metatomic-torch>=0.1.16,<0.2
+    - featomic-torch>=0.7.4,<0.8
     - atomistic-cookbook-utils >=0.1,<0.2
 variables:
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
## Summary

Two recipes fail on the cookbook default branch for different reasons.

`metatomic-plumed` could not solve: `libmetatomic-torch==0.1.7` plus `py-plumed-metatomic` 2.10.0 (which pins `plumed-metatomic` 2.10.0) against `lammps-metatomic` 2026.07.04.mta1 / `plumed-metatomic` 2.10.1.dev1.
This pins those published engine builds.
The example drives PLUMED through LAMMPS and i-PI, so the Python wrapper is omitted until `py-plumed-metatomic` 2.10.1.dev1 is on the channel (https://github.com/metatensor/py-plumed-metatomic-feedstock/pull/5).
`featomic-torch` requires `torch<2.13`, which matches the 2.12 libtorch those engines already use.

`ml-mm` pip-installed `torch>=2.12,<2.13` on top of conda `libtorch 2.13`, then `gmx_mpi mdrun` died in `Module.to` with a mixed-dict error.
This removes the pip torch pin (one libtorch from conda) and the technical comments in `environment.yml`.
The mixed-dict crash is in `metatensor-torch` `Module.to`: https://github.com/metatensor/metatensor/pull/1178

## Test plan

- [x] `conda env create` dry-run for `examples/metatomic-plumed/environment.yml`
- [x] `conda env create` dry-run for `examples/ml-mm/environment.yml`
- [ ] `nox -e metatomic-plumed` with `--no-website`
- [ ] `nox -e ml-mm` with `--no-website` once `libmetatensor-torch` has the mixed-dict `Module.to` fix
- [ ] CI `generate-example` for both recipes
