### PR TITLE
fix(water-model): collect vesin extensions and survive LAMMPS/torch SIGABRT

### DIFF
--- a/examples/water-model/.gitignore
+++ b/examples/water-model/.gitignore
@@ -7,3 +7,4 @@
 data.zip
 log.lammps
 trajectory.xyz
+extensions/

--- a/examples/water-model/data/spcfw.in
+++ b/examples/water-model/data/spcfw.in
@@ -2,8 +2,8 @@ units metal  # Angstroms, eV, picoseconds
 atom_style atomic
 read_data water_32.data
 
-# loads metatomic SPC/Fw model
-pair_style metatomic spcfw-mta.pt
+# loads metatomic SPC/Fw model (extensions/ holds vesin_torch from collect_extensions)
+pair_style metatomic spcfw-mta.pt device cpu extensions extensions/
 pair_coeff * * 1 8
 
 neighbor 2.0 bin

--- a/examples/water-model/data/spcfw.in
+++ b/examples/water-model/data/spcfw.in
@@ -2,7 +2,7 @@ units metal  # Angstroms, eV, picoseconds
 atom_style atomic
 read_data water_32.data
 
-# loads metatomic SPC/Fw model (extensions/ holds vesin_torch from collect_extensions)
+# Metatomic SPC/Fw model; extensions/ is written by collect_extensions on save
 pair_style metatomic spcfw-mta.pt device cpu extensions extensions/
 pair_coeff * * 1 8
 

--- a/examples/water-model/water-model.py
+++ b/examples/water-model/water-model.py
@@ -1109,8 +1109,6 @@ ase.io.write("water_32.data", atoms, format="lammps-data", masses=True)
 # LAMMPS 2026.07 metatomic builds sometimes hit a C++ std::terminate on process
 # exit after a successful run (SIGABRT, returncode -6). Accept that exit status
 # only when the trajectory was written; any other failure still raises.
-from pathlib import Path
-
 _lmp = run_command("lmp -in data/spcfw.in", check=False)
 if _lmp.returncode not in (0, -6) or not Path("trajectory.xyz").is_file():
     raise RuntimeError(

--- a/examples/water-model/water-model.py
+++ b/examples/water-model/water-model.py
@@ -886,7 +886,9 @@ atomistic_model = AtomisticModel(
     qtip4pf_model.eval(), ModelMetadata(), model_capabilities
 )
 
-atomistic_model.save("qtip4pf-mta.pt")
+# Collect Torch extensions (e.g. vesin_torch) next to the model so engines that
+# load the TorchScript file outside Python can resolve them (LAMMPS pair_style).
+atomistic_model.save("qtip4pf-mta.pt", collect_extensions="extensions")
 
 
 # %%
@@ -915,7 +917,7 @@ spcf_model = WaterModel(**spcf_parameters)
 
 atomistic_model = AtomisticModel(spcf_model.eval(), ModelMetadata(), model_capabilities)
 
-atomistic_model.save("spcfw-mta.pt")
+atomistic_model.save("spcfw-mta.pt", collect_extensions="extensions")
 
 # %%
 #

--- a/examples/water-model/water-model.py
+++ b/examples/water-model/water-model.py
@@ -18,6 +18,7 @@ to perform demonstrative molecular dynamics simulations.
 # sphinx_gallery_thumbnail_number = 3
 
 # %%
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import ase.io
@@ -1105,4 +1106,15 @@ for line in lines[:7] + lines[16:]:
 
 ase.io.write("water_32.data", atoms, format="lammps-data", masses=True)
 
-run_command("lmp -in data/spcfw.in")
+# LAMMPS 2026.07 metatomic builds sometimes hit a C++ std::terminate on process
+# exit after a successful run (SIGABRT, returncode -6). Accept that exit status
+# only when the trajectory was written; any other failure still raises.
+from pathlib import Path
+
+_lmp = run_command("lmp -in data/spcfw.in", check=False)
+if _lmp.returncode not in (0, -6) or not Path("trajectory.xyz").is_file():
+    raise RuntimeError(
+        f"LAMMPS failed (returncode={_lmp.returncode}); "
+        f"trajectory.xyz exists={Path('trajectory.xyz').is_file()}"
+    )
+print(f"LAMMPS finished (returncode={_lmp.returncode})")

--- a/examples/water-model/water-model.py
+++ b/examples/water-model/water-model.py
@@ -887,8 +887,7 @@ atomistic_model = AtomisticModel(
     qtip4pf_model.eval(), ModelMetadata(), model_capabilities
 )
 
-# Collect Torch extensions (e.g. vesin_torch) next to the model so engines that
-# load the TorchScript file outside Python can resolve them (LAMMPS pair_style).
+# Bundle native Torch extensions next to the model for non-Python engines.
 atomistic_model.save("qtip4pf-mta.pt", collect_extensions="extensions")
 
 
@@ -1106,13 +1105,11 @@ for line in lines[:7] + lines[16:]:
 
 ase.io.write("water_32.data", atoms, format="lammps-data", masses=True)
 
-# LAMMPS 2026.07 metatomic builds sometimes hit a C++ std::terminate on process
-# exit after a successful run (SIGABRT, returncode -6). Accept that exit status
-# only when the trajectory was written; any other failure still raises.
+# Some metatomic-enabled LAMMPS builds abort in C++ teardown after a successful
+# run (returncode -6). Treat that as success only when the trajectory exists.
 _lmp = run_command("lmp -in data/spcfw.in", check=False)
 if _lmp.returncode not in (0, -6) or not Path("trajectory.xyz").is_file():
     raise RuntimeError(
         f"LAMMPS failed (returncode={_lmp.returncode}); "
         f"trajectory.xyz exists={Path('trajectory.xyz').is_file()}"
     )
-print(f"LAMMPS finished (returncode={_lmp.returncode})")

--- a/src/generate-gallery.py
+++ b/src/generate-gallery.py
@@ -86,7 +86,9 @@ class PseudoSphinxApp:
 
 def _gallery_has_output(example_dir: str) -> bool:
     """True if sphinx-gallery wrote recipe artifacts for this example."""
-    gallery_dir = os.path.join(ROOT, "docs", "src", "examples", os.path.basename(example_dir))
+    gallery_dir = os.path.join(
+        ROOT, "docs", "src", "examples", os.path.basename(example_dir)
+    )
     if not os.path.isdir(gallery_dir):
         return False
     for name in os.listdir(gallery_dir):
@@ -129,8 +131,8 @@ if __name__ == "__main__":
             # Only retry pure teardowns that left no gallery (flaky abort mid-cleanup).
             if last_code in abort_codes and attempt == 0:
                 print(
-                    f"generate-gallery: child exited {last_code} without usable gallery; "
-                    "retrying once",
+                    f"generate-gallery: child exited {last_code} "
+                    "without usable gallery; retrying once",
                     file=sys.__stderr__,
                 )
                 continue

--- a/src/generate-gallery.py
+++ b/src/generate-gallery.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import sys
 import traceback
 
@@ -83,10 +84,58 @@ class PseudoSphinxApp:
         pass
 
 
+def _gallery_has_output(example_dir: str) -> bool:
+    """True if sphinx-gallery wrote recipe artifacts for this example."""
+    gallery_dir = os.path.join(ROOT, "docs", "src", "examples", os.path.basename(example_dir))
+    if not os.path.isdir(gallery_dir):
+        return False
+    for name in os.listdir(gallery_dir):
+        if name.endswith((".rst", ".ipynb", ".py")):
+            return True
+    return False
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(f"usage: {sys.argv[0]} <example/dir>")
         sys.exit(1)
+
+    example_dir = sys.argv[1]
+
+    # Outer driver: run the real gallery build in a child process so a flaky
+    # C++ std::terminate during interpreter teardown (SIGABRT after a successful
+    # recipe, seen with water-model + LAMMPS/torch) does not lose a finished build.
+    # Retry once if the child dies without producing output.
+    if os.environ.get("_ATOMISTIC_COOKBOOK_GALLERY_INNER") != "1":
+        env = {**os.environ, "_ATOMISTIC_COOKBOOK_GALLERY_INNER": "1"}
+        # SIGABRT is -6 from subprocess; some platforms surface 134 (128+6).
+        abort_codes = {-6, 134}
+        last_code = 1
+        for attempt in range(2):
+            proc = subprocess.run(
+                [sys.executable, "-u", __file__, example_dir],
+                env=env,
+            )
+            last_code = proc.returncode
+            if last_code == 0:
+                sys.exit(0)
+            if last_code in abort_codes and _gallery_has_output(example_dir):
+                print(
+                    f"generate-gallery: child exited {last_code} after writing gallery "
+                    f"for {example_dir}; treating as success",
+                    file=sys.__stderr__,
+                )
+                sys.exit(0)
+            # Only retry pure teardowns that left no gallery (flaky abort mid-cleanup).
+            if last_code in abort_codes and attempt == 0:
+                print(
+                    f"generate-gallery: child exited {last_code} without usable gallery; "
+                    "retrying once",
+                    file=sys.__stderr__,
+                )
+                continue
+            break
+        sys.exit(last_code if last_code > 0 else 1)
 
     # To change the download text, we change the ZIP_DOWNLOAD variable in
     # sphinx_gallery.gen_rst. This is a bit of a hack, but arguably not
@@ -101,7 +150,7 @@ if __name__ == "__main__":
         :download:`Download recipe: {0} <{0}>`
     """
 
-    app = PseudoSphinxApp(example=sys.argv[1])
+    app = PseudoSphinxApp(example=example_dir)
     sphinx_gallery.gen_gallery.fill_gallery_conf_defaults(app, app.config)
     sphinx_gallery.gen_gallery.update_gallery_conf_builder_inited(app)
 

--- a/src/generate-gallery.py
+++ b/src/generate-gallery.py
@@ -104,13 +104,12 @@ if __name__ == "__main__":
 
     example_dir = sys.argv[1]
 
-    # Outer driver: run the real gallery build in a child process so a flaky
-    # C++ std::terminate during interpreter teardown (SIGABRT after a successful
-    # recipe, seen with water-model + LAMMPS/torch) does not lose a finished build.
-    # Retry once if the child dies without producing output.
+    # Run the gallery build in a child process. Some torch/native stacks abort
+    # during interpreter teardown after a successful recipe (SIGABRT: -6 or
+    # 134). If the gallery artifacts already exist, treat that as success;
+    # otherwise retry once.
     if os.environ.get("_ATOMISTIC_COOKBOOK_GALLERY_INNER") != "1":
         env = {**os.environ, "_ATOMISTIC_COOKBOOK_GALLERY_INNER": "1"}
-        # SIGABRT is -6 from subprocess; some platforms surface 134 (128+6).
         abort_codes = {-6, 134}
         last_code = 1
         for attempt in range(2):
@@ -123,12 +122,11 @@ if __name__ == "__main__":
                 sys.exit(0)
             if last_code in abort_codes and _gallery_has_output(example_dir):
                 print(
-                    f"generate-gallery: child exited {last_code} after writing gallery "
-                    f"for {example_dir}; treating as success",
+                    f"generate-gallery: child exited {last_code} after writing "
+                    f"gallery for {example_dir}; treating as success",
                     file=sys.__stderr__,
                 )
                 sys.exit(0)
-            # Only retry pure teardowns that left no gallery (flaky abort mid-cleanup).
             if last_code in abort_codes and attempt == 0:
                 print(
                     f"generate-gallery: child exited {last_code} "


### PR DESCRIPTION
## Summary

Factored out of #297 so that PR can stay the `ModelOutput` deprecation fix.

water-model was writing the vesin neighbor list without `collect_extensions`, so LAMMPS `pair_style vesin/metatomic` could not load `libvesin_lammps.so`. It now saves with `collect_extensions="extensions"`, points `pair_style` at `extensions/`, and gitignores that tree.

LAMMPS (and the gallery runner) can still SIGABRT after a successful MD / recipe. `water-model.py` treats returncode `-6` as success only when `trajectory.xyz` exists. `generate-gallery.py` runs the recipe in a child process, accepts `-6`/`134` when gallery artifacts exist, and retries once otherwise.

## Test plan

- [ ] CI `generate-example (water-model)` green
- [ ] lint
- [ ] #297 stays the `ModelOutput` change only
