### PR TITLE
SHIFTML4: Pin upet dependency to current commit

### DIFF
--- a/examples/shiftml4/environment.yml
+++ b/examples/shiftml4/environment.yml
@@ -12,6 +12,6 @@ dependencies:
     - shiftml >=0.2.0,<0.3
     # the "pet-mols-s" model used here is not in a released version of upet yet
     # (0.2.6 on PyPI ships pet-mad/omat/oam/omad/omatpes/spice only), so we
-    # still need to install from git. Switch to a semantic pin once it ships.
-    - upet @ git+https://github.com/lab-cosmo/upet.git@main
+    # still need to install from git. Switch to pypi once it ships.
+    - upet @ git+https://github.com/lab-cosmo/upet.git@788225b
     - atomistic-cookbook-utils >=0.1,<0.2

--- a/examples/shiftml4/shiftml-example.py
+++ b/examples/shiftml4/shiftml-example.py
@@ -20,15 +20,17 @@ accuracy:
    desirable for such purposes. However, relaxing periodic crystals at
    hybrid-functional quality is prohibitively expensive.
 
-This recipe shows how to remove both bottlenecks with machine learning. We use
-`ShiftML4 <https://github.com/lab-cosmo/shiftml>`_ (`Kellner et al.,
-arXiv:2608.21313 <https://arxiv.org/abs/2608.21313>`_), trained on molecular
-corrected periodic GIPAW calculations, which predicts shielding tensors of
-approximate *hybrid-functional* quality directly from the periodic crystal
-structure,
-and `PET-MOLS <https://github.com/lab-cosmo/upet>`_, a machine-learned
-interatomic potential that relaxes molecular crystals to approximate PBE0+MBD
-geometries in seconds/minutes rather than CPU-hours.
+This recipe shows how to remove both bottlenecks with machine learning, using
+one model for each:
+
+1. `ShiftML4 <https://github.com/lab-cosmo/shiftml>`_ (`Kellner et al.,
+   arXiv:2608.21313 <https://arxiv.org/abs/2608.21313>`_), trained on molecular
+   corrected periodic GIPAW calculations, which predicts shielding tensors of
+   approximate *hybrid-functional* quality directly from the periodic crystal
+   structure.
+2. `PET-MOLS <https://github.com/lab-cosmo/upet>`_, a machine-learned
+   interatomic potential that relaxes molecular crystals to approximate PBE0+MBD
+   geometries in seconds/minutes rather than CPU-hours.
 
 We deliberately pick two :sup:`13`\ C sites that are known to be *hard* problems
 for shift prediction:
@@ -54,7 +56,9 @@ determination with ShiftML3
 <http://atomistic-cookbook.org/examples/shiftml-structure-match/shiftml-structure-match.html>`_.
 """
 
+# sphinx_gallery_start_ignore
 # sphinx_gallery_thumbnail_path = '../../examples/shiftml4/testosterone-c5.png'
+# sphinx_gallery_end_ignore
 
 # %%
 


### PR DESCRIPTION
This is a leftover of #300 , I didn't realise that it was not using a `upet` release. For now we will pin it to the current commit to avoid depending on `main` which can change at any time and break the cookbook example.